### PR TITLE
Add tests to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ stages:
 jobs:
   include:
     - stage: "Tests"
-      name: "Admin test"
+      name: "Admin tests"
       language: node_js
       node_js:
         - "8"
@@ -22,10 +22,12 @@ jobs:
       script:
         - yarn test && yarn build
 
-    - name: "Backend test"
+    - name: "Backend tests"
       language: python
       python:
         - 3.6
+      cache:
+        pip: true
       services:
         - docker
         - mongodb
@@ -36,6 +38,21 @@ jobs:
         - pip install -r requirements.txt
       script:
         - PYTHONPATH=`pwd` pytest --cov=src
+
+    - name: "Frontend tests"
+      language: python
+      python:
+        - 3.6
+      cache:
+        pip: true
+      before_install:
+        - cd frontend
+      install:
+        - pip install -r requirements.txt
+        - pip install pytest py-w3c
+      script:
+        - BACKEND_URL=https://www.research-software.nl/api PYTHONPATH=. pytest --live
+
 
     - stage: "docker-compose integration tests"
       before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
       before_install:
         - cd backend
       install:
-        - pip install pytest pytest-cov coveralls
+        - pip install pytest==4.3.0 pytest-cov coveralls
         - pip install -r requirements.txt
       script:
         - PYTHONPATH=`pwd` pytest --cov=src

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,46 @@
-before_install:
-  - cp rsd-secrets.env.example rsd-secrets.env
-  - source rsd-secrets.env
-  - docker-compose --project-name rsd build
-script:
-  - docker-compose --project-name rsd --file docker-compose.yml --file docker-compose.test.yml run test
+stages:
+  - "Tests"
+  - "docker-compose integration tests"
+#  - name: "Docker build & push"
+#    if: branch = master
+
+jobs:
+  include:
+    - stage: "Tests"
+      name: "Admin test"
+      language: node_js
+      node_js:
+        - "8"
+      cache:
+        directories:
+          - node_modules
+#          - /home/travis/.cache/Cypress
+      before_install:
+        - cd admin
+      install:
+        - yarn
+      script:
+        - yarn test && yarn build
+
+    - name: "Backend test"
+      language: python
+      python:
+        - 3.6
+      services:
+        - docker
+        - mongodb
+      before_install:
+        - cd backend
+      install:
+        - pip install pytest pytest-cov coveralls
+        - pip install -r requirements.txt
+      script:
+        - PYTHONPATH=`pwd` pytest --cov=src
+
+    - stage: "docker-compose integration tests"
+      before_install:
+        - cp rsd-secrets.env.example rsd-secrets.env
+        - source rsd-secrets.env
+        - docker-compose --project-name rsd build
+      script:
+        - docker-compose --project-name rsd --file docker-compose.yml --file docker-compose.test.yml run test


### PR DESCRIPTION
Sets up .travis.yml so that it runs in parallel:
- admin tests
- backend tests
- frontend tests

When all are successful, it will run the docker-compose integration test suite (which is a dummy pretty much at the moment though, so you might want to disable this one for now, to speed up test runs).