### PR TITLE
Schema dot org

### DIFF
--- a/backend/schemas/release.json
+++ b/backend/schemas/release.json
@@ -13,7 +13,7 @@
         "isCitable": {
             "type": "boolean"
         },
-        "latestCodemeta": {
+        "latestSchema_dot_org": {
             "type": "string"
         },
         "primaryKey": {
@@ -41,7 +41,7 @@
                             "cff": {
                                 "type": "string"
                             },
-                            "codemeta": {
+                            "schema_dot_org": {
                                 "type": "string"
                             },
                             "endnote": {
@@ -54,9 +54,9 @@
                         "required": [
                             "bibtex",
                             "cff",
-                            "codemeta",
                             "endnote",
-                            "ris"
+                            "ris",
+                            "schema_dot_org"
                         ],
                         "type": "object"
                     },

--- a/frontend/templates/software/metadata.html
+++ b/frontend/templates/software/metadata.html
@@ -1,5 +1,5 @@
-{% if template_data.latestCodemeta %}
+{% if template_data.latestSchema_dot_org %}
     <script type="application/ld+json">
-        {{ template_data.latestCodemeta | safe }}
+        {{ template_data.latestSchema_dot_org | safe }}
     </script>
 {% endif %}

--- a/harvesting/cache_software.py
+++ b/harvesting/cache_software.py
@@ -78,7 +78,7 @@ def cache_software():
         if release_document:
             sw['releases'] = release_document['releases']
             sw['isCitable'] = release_document['isCitable']
-            sw['latestCodemeta'] = release_document['latestCodemeta']
+            sw['latestSchema_dot_org'] = release_document['latestSchema_dot_org']
         else:
             sw['releases'] = []
         db.software_cache.replace_one({'_id': sw['_id']}, sw, upsert=True)

--- a/harvesting/releases.py
+++ b/harvesting/releases.py
@@ -20,7 +20,7 @@ class ReleaseScraper:
         5. on github, check if there is a cff
         foreach cff
         6. validate the cff
-        7. generate bibtex, ris, endnote, and codemeta strings
+        7. generate bibtex, ris, endnote, and schema.org strings
 
     After initialization, the ReleaseScraper instance has a field .releases which is
     an array of objects with one of the following layouts:
@@ -31,7 +31,7 @@ class ReleaseScraper:
         "files": {
             "bibtex": "file contents",
             "cff": "file contents",
-            "codemeta": "file contents",
+            "schema_dot_org": "file contents",
             "endnote": "file contents",
             "ris": "file contents"
         },
@@ -48,7 +48,7 @@ class ReleaseScraper:
     """
 
     def __init__(self, doi):
-        self.latest_codemeta = None
+        self.latest_schema_dot_org = None
         self.releases = list()
         self.is_citable = False
         self.zenodo_data = dict(conceptdoi=None, versioned_dois=None)
@@ -96,13 +96,13 @@ class ReleaseScraper:
         if True not in [release["citability"] == "full" for release in self.releases]:
             self.message = "no valid CITATION.cff found in any release."
             return
-        self.determine_latest_codemeta()
+        self.determine_latest_schema_dot_org()
         self.message = "OK"
 
-    def determine_latest_codemeta(self):
+    def determine_latest_schema_dot_org(self):
         for release in self.releases:
-            if "codemeta" in release["files"].keys():
-                self.latest_codemeta = release["files"]["codemeta"]
+            if "schema_dot_org" in release["files"].keys():
+                self.latest_schema_dot_org = release["files"]["schema_dot_org"]
                 return self
 
     def filter_zenodo_data_versioned_dois(self):
@@ -173,7 +173,7 @@ class ReleaseScraper:
                     release["files"] = dict({
                         "bibtex": citation.as_bibtex(),
                         "cff": citation.cffstr,
-                        "codemeta": citation.as_codemeta(),
+                        "schema_dot_org": citation.as_schema_dot_org(),
                         "endnote": citation.as_enw(),
                         "ris": citation.as_ris()
                     })
@@ -220,7 +220,7 @@ def get_citations(db, dois):
                 "_id": doi,
                 "isCitable": release.is_citable,
                 "conceptDOI": doi,
-                "latestCodemeta": "" if release.latest_codemeta is None else release.latest_codemeta,
+                "latestSchema_dot_org": "" if release.latest_schema_dot_org is None else release.latest_schema_dot_org,
                 "releases": release.releases,
                 "createdAt": datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
             }

--- a/harvesting/releases_livetest.py
+++ b/harvesting/releases_livetest.py
@@ -35,5 +35,6 @@ class ReleaseScraperTest(unittest.TestCase):
         expected_message = "no valid CITATION.cff found in any release."
         self.assertEqual(expected_message, actual_message)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/harvesting/requirements.txt
+++ b/harvesting/requirements.txt
@@ -5,5 +5,5 @@ python-dateutil==2.6.1
 Pyzotero==1.3.1
 dateutils==0.6.6
 pymongo==3.6.1
-cffconvert==1.2.1
+cffconvert==1.3.0
 PyJWT==1.5.3


### PR DESCRIPTION
Google's https://search.google.com/structured-data/testing-tool was reporting errors due to CodeMeta being included in the ``@context``. I've since updated cffconvert ([1.3.0](https://github.com/citation-file-format/cff-converter-python/releases/tag/1.3.0)) to be able to generate schema.org json-ld. The errors we are having may negatively affect the search engine ranking.

This PR therefore replaces the codemeta based metadata with schema.org based metadata.