### PR TITLE
avoid extra spaces when copying doi to clipboard

### DIFF
--- a/frontend/templates/software/citation.html
+++ b/frontend/templates/software/citation.html
@@ -36,9 +36,7 @@
                     <div class="row">
                         <div class="doi_url">
                             <span class="gradient"></span>
-                            <span id="doi">
-                                [[ releases.length > 0 ? releases[selectedIndex].doi : conceptDOI ]]
-                            </span>
+                            <span id="doi">[[ releases.length > 0 ? releases[selectedIndex].doi : conceptDOI ]]</span>
                         </div>
                         <div class="button button--filled-blue copy" href="#">
                             <span><svg class="icon"><use xlink:href="{{url_for('static', filename='icons/icons.svg')}}#icon-clipboard"></use></svg></span>


### PR DESCRIPTION
The ``span``s need to be immediately adjacent to the content, otherwise you get annoying behavior on Firefox (but not Chrome) where the pasted content has a leading and a trailing space.
