### PR TITLE
citation exports

### DIFF
--- a/backend/schemas/release.json
+++ b/backend/schemas/release.json
@@ -41,13 +41,16 @@
                             "cff": {
                                 "type": "string"
                             },
-                            "schema_dot_org": {
+                            "codemeta": {
                                 "type": "string"
                             },
                             "endnote": {
                                 "type": "string"
                             },
                             "ris": {
+                                "type": "string"
+                            },
+                            "schema_dot_org": {
                                 "type": "string"
                             }
                         },

--- a/backend/schemas/software_cache.json
+++ b/backend/schemas/software_cache.json
@@ -157,10 +157,16 @@
                                 "cff": {
                                     "type": "string"
                                 },
+                                "codemeta": {
+                                    "type": "string"
+                                },
                                 "endnote": {
                                     "type": "string"
                                 },
                                 "ris": {
+                                    "type": "string"
+                                },
+                                "schema_dot_org": {
                                     "type": "string"
                                 }
                             },

--- a/frontend/app/application.py
+++ b/frontend/app/application.py
@@ -150,9 +150,16 @@ def cite(software_id):
         if release['tag'] == flask.request.args.get('version'):
             for file_format in release['files'].keys():
                 if file_format == flask.request.args.get('format'):
+                    filenames = {
+                        "bibtex": "{0}.bib".format(software_id),
+                        "cff": "CITATION.cff",
+                        "codemeta": "codemeta.json",
+                        "endnote": "{0}.enw".format(software_id),
+                        "ris": "{0}.ris".format(software_id)
+                    }
                     return flask.Response(
                         release['files'][file_format],
-                        headers={"Content-disposition": "attachment; filename=%s.%s" % (software_id, file_format)}
+                        headers={"Content-disposition": "attachment; filename={0}".format(filenames[file_format])}
                     )
 
     return flask.abort(404)

--- a/frontend/app/application.py
+++ b/frontend/app/application.py
@@ -150,16 +150,34 @@ def cite(software_id):
         if release['tag'] == flask.request.args.get('version'):
             for file_format in release['files'].keys():
                 if file_format == flask.request.args.get('format'):
-                    filenames = {
-                        "bibtex": "{0}.bib".format(software_id),
-                        "cff": "CITATION.cff",
-                        "codemeta": "codemeta.json",
-                        "endnote": "{0}.enw".format(software_id),
-                        "ris": "{0}.ris".format(software_id)
+                    names_and_types = {
+                        "bibtex": {
+                            "name": "{0}.bib".format(software_id),
+                            "content-type": "application/x-bibtex"
+                        },
+                        "cff": {
+                            "name": "CITATION.cff",
+                            "content-type": "text/yaml"
+                        },
+                        "codemeta": {
+                            "name": "codemeta.json",
+                            "content-type": "application/json"
+                        },
+                        "endnote": {
+                            "name": "{0}.enw".format(software_id),
+                            "content-type": "text/plain"
+                        },
+                        "ris": {
+                            "name": "{0}.ris".format(software_id),
+                            "content-type": "application/x-research-info-systems"
+                        },
                     }
                     return flask.Response(
                         release['files'][file_format],
-                        headers={"Content-disposition": "attachment; filename={0}".format(filenames[file_format])}
+                        headers={
+                            "Content-disposition": "attachment; filename={0}".format(names_and_types[file_format]["name"]),
+                            "Content-Type": names_and_types[file_format]["content-type"]
+                        }
                     )
 
     return flask.abort(404)

--- a/frontend/templates/software/citation.html
+++ b/frontend/templates/software/citation.html
@@ -46,24 +46,24 @@
                 </div>
 
                 <div class="citation-block_download" v-if="releases.length > 0 && releases[selectedIndex].citability === 'full'">
-                    <h5>Choose a citation style:</h5>
+                    <h5>Choose a reference manager file format:</h5>
                     <div class="row">
                         <div :class="['dropdown', fileFormatDropdownOpen && 'is-active']" @click="fileFormatDropdownOpen = !fileFormatDropdownOpen">
                             <div class="dropdown_button dropdown_button--light">
-                                <span class="text">[[ fileFormats[selectedFileFormatIndex].name ]]</span>
+                                <span class="text">[[ fileFormats[selectedFileFormatIndex].displayName ]]</span>
                                 <svg class="icon"><use xlink:href="{{url_for('static', filename='icons/icons.svg')}}#icon-chev-down"></use></svg>
                             </div>
                             <div class="dropdown_panel dropdown_panel--light">
                                 <ul>
                                     <li v-for="(format, index) in fileFormats" @click="selectedFileFormatIndex = index">
                                         <span class="inside">
-                                            <span class="text">[[ format.name ]]</span>
+                                            <span class="text">[[ format.displayName ]]</span>
                                         </span>
                                     </li>
                                 </ul>
                             </div>
                         </div>
-                        <a class="button button--filled-blue download" :href="'/cite/{{template_data.slug}}?version='+encodeURI(releases[selectedIndex].tag)+'&format='+fileFormats[selectedFileFormatIndex].extension" download>
+                        <a class="button button--filled-blue download" :href="'/cite/{{template_data.slug}}?version='+encodeURI(releases[selectedIndex].tag)+'&format='+fileFormats[selectedFileFormatIndex].key" download>
                             <span><svg class="icon"><use xlink:href="{{url_for('static', filename='icons/icons.svg')}}#icon-download"></use></svg></span>
                             <span>Download file</span>
                         </a>
@@ -85,9 +85,11 @@
                 versionDropdownOpen: false,
                 fileFormatDropdownOpen: false,
                 fileFormats: [
-                    { extension: 'bibtex', name: 'BibTeX' },
-                    { extension: 'endnote', name: 'EndNote' },
-                    { extension: 'ris', name: 'RIS' }
+                    { key: 'bibtex'  , displayName: 'BibTeX' },
+                    { key: 'endnote' , displayName: 'EndNote' },
+                    { key: 'ris'     , displayName: 'RIS' },
+                    { key: 'codemeta', displayName: 'CodeMeta' },
+                    { key: 'cff'     , displayName: 'Citation File Format' }
                 ],
                 selectedFileFormatIndex: 0
             }

--- a/harvesting/releases.py
+++ b/harvesting/releases.py
@@ -186,6 +186,7 @@ class ReleaseScraper:
                 try:
                     release["files"] = dict({
                         "bibtex": citation.as_bibtex(),
+                        "codemeta": citation.as_codemeta(),
                         "cff": citation.cffstr,
                         "schema_dot_org": citation.as_schema_dot_org(),
                         "endnote": citation.as_enw(),


### PR DESCRIPTION
- added codemeta and cff as downloadable reference manager files;
- updated the schemas accordingly;
- changed the download file naming scheme to comply with standards (.bib, .enw extensions, CITATION.cff, codemeta.json)

refs #374 