### PR TITLE
added rule for failed url request

### DIFF
--- a/harvesting/oaipmh.py
+++ b/harvesting/oaipmh.py
@@ -6,6 +6,7 @@ import requests
 from requests.exceptions import HTTPError
 import time
 import pymongo
+from util import rate_limit_reached
 
 db = pymongo.MongoClient(host=os.environ.get('DATABASE_HOST'),
                          port=int(os.environ.get('DATABASE_PORT')),
@@ -59,10 +60,11 @@ def list_records(dois):
 
     def get_datacite():
         response = requests.get(url, headers=headers)
-        if int(response.headers.get('x-ratelimit-remaining')) < 10:
+        while rate_limit_reached(response):
             # throttle requests
             logger.info("Sleeping for 60 seconds to avoid HttpError 429")
             time.sleep(60)
+            response = requests.get(url, headers=headers)
         if response.status_code != requests.codes.ok:
             response.raise_for_status()
 

--- a/harvesting/releases.py
+++ b/harvesting/releases.py
@@ -6,6 +6,7 @@ import time
 
 import requests
 from cffconvert import Citation
+from util import rate_limit_reached
 
 logger = logging.getLogger(__name__)
 
@@ -150,9 +151,11 @@ class ReleaseScraper:
             'Authorization': 'Bearer ' + os.environ.get('ZENODO_ACCESS_TOKEN')
         }
         r = requests.get(url, headers=headers)
-        if int(r.headers.get('x-ratelimit-remaining')) < 10:
+        while rate_limit_reached(r):
             # throttle requests
+            logger.info("Rate limit reached: sleeping for 60 seconds")
             time.sleep(60)
+            r = requests.get(url, headers=headers)
         r.raise_for_status()
         self.zenodo_data["conceptdoi"] = r.json()
         return self
@@ -163,9 +166,11 @@ class ReleaseScraper:
             'Authorization': 'Bearer ' + os.environ.get('ZENODO_ACCESS_TOKEN')
         }
         r = requests.get(url, headers=headers)
-        if int(r.headers.get('x-ratelimit-remaining')) < 10:
+        while rate_limit_reached(r):
             # throttle requests
+            logger.info("Rate limit reached: sleeping for 60 seconds")
             time.sleep(60)
+            r = requests.get(url, headers=headers)
         r.raise_for_status()
         self.zenodo_data["versioned_dois"] = r.json()
         hits = self.zenodo_data["versioned_dois"]["hits"]["hits"]

--- a/harvesting/releases_livetest.py
+++ b/harvesting/releases_livetest.py
@@ -8,7 +8,7 @@ class ReleaseScraperTest(unittest.TestCase):
         conceptdoi = "10.0000/FIXME"
         self.scraper = ReleaseScraper(conceptdoi)
         actual_message = self.scraper.message
-        expected_message = "error resolving doi."
+        expected_message = "error 404 resolving doi."
         self.assertEqual(expected_message, actual_message)
 
     def test_conceptdoi_is_not_a_zenodo_doi(self):
@@ -29,7 +29,7 @@ class ReleaseScraperTest(unittest.TestCase):
 
     def test_conceptdoi_no_releases_with_valid_cff(self):
         # use a doi that has no associated releases with valid CFF data
-        conceptdoi = "10.5281/zenodo.1193639"
+        conceptdoi = "10.5281/zenodo.996323"
         self.scraper = ReleaseScraper(conceptdoi)
         actual_message = self.scraper.message
         expected_message = "no valid CITATION.cff found in any release."

--- a/harvesting/util.py
+++ b/harvesting/util.py
@@ -67,3 +67,10 @@ def db_connect():
                                connectTimeoutMS=100,
                                serverSelectionTimeoutMS=100
                                )[os.environ.get('DATABASE_NAME')]
+
+def rate_limit_reached(requests_response):
+    try:
+        rate_limit_check = requests_response.headers.get('x-ratelimit-remaining')
+        if int(rate_limit_check) < 10: return True
+        else: return False
+    except: return True


### PR DESCRIPTION
Solves issue #434 by dealing with failed url requests by testing for fail and in case of success waiting for 60 seconds before repeating the request