### PR TITLE
udpated requirements to match what pyzotero is asking

### DIFF
--- a/harvesting/requirements.txt
+++ b/harvesting/requirements.txt
@@ -1,6 +1,6 @@
 beautifulsoup4==4.6.0
 click==6.7
-requests==2.20.0
+requests>=2.21.0
 python-dateutil==2.6.1
 Pyzotero==1.4.18
 dateutils==0.6.6


### PR DESCRIPTION
Refs #449. ~~I didn't test this yet, I just made this PR via the GitHub frontend, hence it's marked as draft. Whoever wants to test it, feel free ot undraft.~~

I tried it out, works as normal when following the section ["Verifying the local installation"](https://github.com/research-software-directory/research-software-directory/tree/f5861de2c4b5373300110fc0dc08febb505a9709#verifying-the-local-installation), and no longer gives the warning during build. `docker-compose exec harvesting python app.py harvest all` and `docker-compose exec harvesting python app.py resolve all` also work.

