### PR TITLE
workflow now uses same node version as Dockerfile

### DIFF
--- a/.github/workflows/admin_tests.yml
+++ b/.github/workflows/admin_tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, ubuntu-latest]
-        node-version: [12.x]
+        node-version: [14.13.0]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
node version is now consistent throughout the whole stack
It's specified down to patch version, which may be a bit too much. Accroding to this https://hub.docker.com/_/node?tab=description&page=1&name=node , we could do `14.13-alpine` or even `14-alpine`.

PS frontend workflows are failing due to #471.