### PR TITLE
upgrade python

### DIFF
--- a/.github/workflows/backend_tests.yml
+++ b/.github/workflows/backend_tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, ubuntu-latest]
-        python-version: [3.6]
+        python-version: [3.8]
         mongodb-version: [3.6]
 
     steps:

--- a/.github/workflows/frontend_tests.yml
+++ b/.github/workflows/frontend_tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, ubuntu-latest]
-        python-version: [3.6]
+        python-version: [3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/auth-github/Dockerfile
+++ b/auth-github/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-alpine
+FROM python:3.8-alpine
 
 COPY requirements.txt /requirements.txt
 RUN pip install -r /requirements.txt

--- a/auth-github/Dockerfile
+++ b/auth-github/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-alpine
+FROM python:3.9-alpine
 
 COPY requirements.txt /requirements.txt
 RUN pip install -r /requirements.txt

--- a/auth-github/requirements.txt
+++ b/auth-github/requirements.txt
@@ -2,6 +2,6 @@ Flask==1.0
 Flask-Cors==3.0.3
 requests==2.20.0
 urllib3==1.24.2
-gunicorn==19.7.1
+gunicorn==20.0.4
 pytest==3.3.2
 PyJWT==1.5.3

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-alpine
+FROM python:3.8-alpine
 
 COPY requirements.txt /requirements.txt
 RUN pip install -r /requirements.txt

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-alpine
+FROM python:3.9-alpine
 
 COPY requirements.txt /requirements.txt
 RUN pip install -r /requirements.txt

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,6 +2,6 @@ Flask==1.1
 Flask-Cors==3.0.3
 requests==2.20.0
 jsonschema==2.6.0
-gunicorn==19.7.1
+gunicorn==20.0.4
 PyJWT==1.5.3
 pymongo==3.6.1

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-alpine
+FROM python:3.8-alpine
 
 RUN apk update && apk add --no-cache build-base
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-alpine
+FROM python:3.9-alpine
 
 RUN apk update && apk add --no-cache build-base
 

--- a/frontend/app/application.py
+++ b/frontend/app/application.py
@@ -97,7 +97,7 @@ def index():
 
 def set_markdown(software, fields):
     for field in fields:
-        if field in software and software[field] and software[field] is not '':
+        if field in software and software[field] and software[field] != '':
             software[field] = flask.Markup(markdown.markdown(software[field]))
         else:
             software[field] = None

--- a/frontend/requirements.txt
+++ b/frontend/requirements.txt
@@ -4,7 +4,7 @@ Markdown
 ago==0.0.92
 htmlmin==0.1.12
 pprintpp==0.4
-gunicorn==19.7.1
+gunicorn==20.0.4
 dateutils==0.6.6
 requests-mock==1.4.0
 libsass==0.17.0

--- a/harvesting/Dockerfile
+++ b/harvesting/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-alpine
+FROM python:3.9-alpine
 
 
 RUN mkdir /app

--- a/harvesting/Dockerfile
+++ b/harvesting/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-alpine
+FROM python:3.8-alpine
 
 
 RUN mkdir /app


### PR DESCRIPTION
Refs #474

Upgraded all pythons from 3.6 to 3.9 but doesnt work:

```shell
$ docker-compose exec harvesting python app.py harvest all
Traceback (most recent call last):
  File "/app/app.py", line 8, in <module>
    from zotero import get_mentions
  File "/app/zotero.py", line 10, in <module>
    from pyzotero import zotero
  File "/usr/local/lib/python3.9/site-packages/pyzotero/zotero.py", line 43, in <module>
    import feedparser
  File "/usr/local/lib/python3.9/site-packages/feedparser.py", line 93, in <module>
    _base64decode = getattr(base64, 'decodebytes', base64.decodestring)
AttributeError: module 'base64' has no attribute 'decodestring'
```

Trying Python 3.8 next.

```shell
$ docker-compose build && docker-compose up -d && docker-compose logs --follow
```
shows 
```
rsd-backend      | [2020-10-14 17:16:31 +0000] [1] [INFO] Starting gunicorn 19.7.1
rsd-backend      | [2020-10-14 17:16:31 +0000] [1] [INFO] Listening at: http://0.0.0.0:5001 (1)
rsd-backend      | [2020-10-14 17:16:31 +0000] [1] [INFO] Using worker: sync
rsd-backend      | /usr/local/lib/python3.8/os.py:1023: RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode, the default buffer size will be used
rsd-backend      |   return io.open(fd, *args, **kwargs)
rsd-backend      | [2020-10-14 17:16:31 +0000] [9] [INFO] Booting worker with pid: 9
rsd-backend      | /usr/local/lib/python3.8/os.py:1023: RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode, the default buffer size will be used
rsd-backend      |   return io.open(fd, *args, **kwargs)
rsd-backend      | [2020-10-14 17:16:31 +0000] [10] [INFO] Booting worker with pid: 10
rsd-backend      | /usr/local/lib/python3.8/os.py:1023: RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode, the default buffer size will be used
rsd-backend      |   return io.open(fd, *args, **kwargs)
rsd-backend      | [2020-10-14 17:16:31 +0000] [11] [INFO] Booting worker with pid: 11
```
and

```shell
rsd-frontend     | /src/app/application.py:100: SyntaxWarning: "is not" with a literal. Did you mean "!="?
rsd-frontend     |   if field in software and software[field] and software[field] is not '':
rsd-frontend     | [2020-10-14 17:16:34 +0000] [1] [INFO] Starting gunicorn 19.7.1
rsd-frontend     | [2020-10-14 17:16:34 +0000] [1] [INFO] Listening at: http://0.0.0.0:5004 (1)
rsd-frontend     | [2020-10-14 17:16:34 +0000] [1] [INFO] Using worker: sync
rsd-frontend     | /usr/local/lib/python3.8/os.py:1023: RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode, the default buffer size will be used
rsd-frontend     |   return io.open(fd, *args, **kwargs)
rsd-frontend     | [2020-10-14 17:16:34 +0000] [9] [INFO] Booting worker with pid: 9
rsd-frontend     | /usr/local/lib/python3.8/os.py:1023: RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode, the default buffer size will be used
rsd-frontend     |   return io.open(fd, *args, **kwargs)
rsd-frontend     | [2020-10-14 17:16:34 +0000] [10] [INFO] Booting worker with pid: 10
rsd-frontend     | /usr/local/lib/python3.8/os.py:1023: RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode, the default buffer size will be used
rsd-frontend     |   return io.open(fd, *args, **kwargs)
rsd-frontend     | [2020-10-14 17:16:34 +0000] [11] [INFO] Booting worker with pid: 11
```
and
```shell
rsd-authentication | [2020-10-14 17:16:28 +0000] [1] [INFO] Starting gunicorn 19.7.1
rsd-authentication | [2020-10-14 17:16:28 +0000] [1] [INFO] Listening at: http://0.0.0.0:5002 (1)
rsd-authentication | [2020-10-14 17:16:28 +0000] [1] [INFO] Using worker: sync
rsd-authentication | /usr/local/lib/python3.8/os.py:1023: RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode, the default buffer size will be used
rsd-authentication |   return io.open(fd, *args, **kwargs)
rsd-authentication | [2020-10-14 17:16:28 +0000] [7] [INFO] Booting worker with pid: 7
rsd-authentication | /usr/local/lib/python3.8/os.py:1023: RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode, the default buffer size will be used
rsd-authentication |   return io.open(fd, *args, **kwargs)
rsd-authentication | [2020-10-14 17:16:28 +0000] [8] [INFO] Booting worker with pid: 8
rsd-authentication | /usr/local/lib/python3.8/os.py:1023: RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode, the default buffer size will be used
rsd-authentication |   return io.open(fd, *args, **kwargs)
rsd-authentication | [2020-10-14 17:16:28 +0000] [9] [INFO] Booting worker with pid: 9
```
So it looks like `frontend` runs into this error: https://github.com/benoitc/gunicorn/issues/2091 although we have `gunicorn==19.7.1`, in `frontend`, `backend` and ``authentication``. Besides the warnings in the log, it seems to work fine though, at least all the parts from ["Verifying the local installation"](https://github.com/research-software-directory/research-software-directory/blob/7f796b0af89b7d34541e9efc39872f767fb13c22/docs/dev.md#verifying-the-local-installation) work as expected.


The syntax error about `is not` seems a real error, I've changed it as suggested.

Based on gunicorns changelog, we should be able to update to 20.x. The breaking changes don't seem relevant to us. https://docs.gunicorn.org/en/latest/news.html

After updating gunicorn: Logs look clean now, also when I do a `harvest all`. ["Verifying the local installation"](https://github.com/research-software-directory/research-software-directory/blob/7f796b0af89b7d34541e9efc39872f767fb13c22/docs/dev.md#verifying-the-local-installation) works as expected. but I saw #518 in the logs. From a user perspective, everything works though.

