### PR TITLE
stop xenon download from being so alarmist during build of backup

### DIFF
--- a/backup/Dockerfile
+++ b/backup/Dockerfile
@@ -7,7 +7,7 @@ COPY ./backup.sh /app/backup.sh
 COPY ./crontab /var/spool/cron/crontabs/root
 
 WORKDIR /app
-RUN wget https://github.com/NLeSC/xenon-cli/releases/download/v2.4.1/xenon-cli-shadow-2.4.1.tar && sync && tar -xf xenon-cli-shadow-2.4.1.tar
+RUN wget https://github.com/NLeSC/xenon-cli/releases/download/v2.4.1/xenon-cli-shadow-2.4.1.tar 2>&1 && sync && tar -xf xenon-cli-shadow-2.4.1.tar
 
 ENV PATH "$PATH:/app/xenon-cli-shadow-2.4.1/bin/"
 


### PR DESCRIPTION
This PR makes the wget of the xenon jar print on standard out instead of stderr.