### PR TITLE
Make bg color of tags lighter

### DIFF
--- a/frontend/style/templates/_software.scss
+++ b/frontend/style/templates/_software.scss
@@ -316,10 +316,6 @@ section{
         li{
             margin: 2px;
             padding: 0.5em 0.8em;  
-
-            &.bg-light{
-                background-color: darken( $light, 4% );
-            }
         }
     }
     .githublogo{


### PR DESCRIPTION
## Description
Changes:
Removed function in __software.scss_ that darkened the Tag background. Now the tag will take the default light-bg color of #eee

## Related Issues
#568 `bg color of tags lighter`