### PR TITLE
452 principalinvestigator

### DIFF
--- a/frontend/app/application.py
+++ b/frontend/app/application.py
@@ -103,12 +103,26 @@ def set_markdown(software, fields):
             software[field] = None
 
 
+def fetch_team_member_data(team_member):
+    person_id = team_member['foreignKey']['id']
+    url = api_url + "/person/%s" % person_id
+    person_dictionary = requests.get(url).json()
+    if "error" in person_dictionary:
+        return team_member
+    team_member.update(person_dictionary)
+    return team_member
+ 
+
 @application.route('/software/<software_id>')
 def software_product_page_template(software_id):
     url = api_url + "/software_cache/%s" % software_id
     software_dictionary = requests.get(url).json()
     if "error" in software_dictionary:
         return flask.redirect("/", code=302)
+    for i in range(0,len(software_dictionary['related']['projects'])):
+        for j in range(0,len(software_dictionary['related']['projects'][i]['foreignKey']['team'])):
+            software_dictionary['related']['projects'][i]['foreignKey']['team'][j] = \
+                fetch_team_member_data(software_dictionary['related']['projects'][i]['foreignKey']['team'][j])
     set_markdown(software_dictionary, ['statement', 'shortStatement', 'readMore'])
 
     mention_types = {
@@ -209,6 +223,10 @@ def project_page_template(project_id):
     project_dictionary = requests.get(url).json()
     if "error" in project_dictionary:
         return flask.redirect("/", code=302)
+    for i in range(0,len(project_dictionary['related']['projects'])):
+        for j in range(0,len(project_dictionary['related']['projects'][i]['foreignKey']['team'])):
+            project_dictionary['related']['projects'][i]['foreignKey']['team'][j] = \
+                fetch_team_member_data(project_dictionary['related']['projects'][i]['foreignKey']['team'][j])
 
     set_markdown(project_dictionary, ['description'])
 

--- a/frontend/app/application.py
+++ b/frontend/app/application.py
@@ -223,10 +223,9 @@ def project_page_template(project_id):
     project_dictionary = requests.get(url).json()
     if "error" in project_dictionary:
         return flask.redirect("/", code=302)
-    for i in range(0,len(project_dictionary['related']['projects'])):
-        for j in range(0,len(project_dictionary['related']['projects'][i]['foreignKey']['team'])):
-            project_dictionary['related']['projects'][i]['foreignKey']['team'][j] = \
-                fetch_team_member_data(project_dictionary['related']['projects'][i]['foreignKey']['team'][j])
+    for project in project_dictionary['related']['projects']:
+        for team in project['foreignKey']['team']:
+            team.update(fetch_team_member_data(team))
 
     set_markdown(project_dictionary, ['description'])
 

--- a/frontend/templates/project/related_projects.html
+++ b/frontend/templates/project/related_projects.html
@@ -7,7 +7,6 @@
             </div>
             <div class="col-3-4">
                 <div class="row project-items">
-
                     {% for fpproject in template_data.related.projects | no_none_filter %}
                     {% with project = fpproject.foreignKey %}
                     <article class="project-item col-1-2">
@@ -21,11 +20,6 @@
                                     <p>
                                         {{project.subtitle}}
                                     </p>
-                                    <div class="author">
-                                        <div class="author_name">
-                                            {{ project.principalInvestigator }}
-                                        </div>
-                                    </div>
                                 </div>
                             </div>
                         </a>

--- a/frontend/templates/software/projects.html
+++ b/frontend/templates/software/projects.html
@@ -21,11 +21,6 @@
                                     <p>
                                         {{project.subtitle}}
                                     </p>
-                                    <div class="author">
-                                        <div class="author_name">
-                                            {{ project.principalInvestigator }}
-                                        </div>
-                                    </div>
                                 </div>
                             </div>
                         </a>


### PR DESCRIPTION
PI has been removed from related projects block, both in software listing and project listing, cf issue #575 . Additionally, code has been added so that information about the teams of related projects can be displayed on the website in the future cf. issue #452 . In that case, the following code snippet can be added to the templates (example for principal investigator):
```
<div class="author">
    <div class="author_name">
        {% for team_member in project.team %}
            {% if team_member.role == 'Principal investigator' %}
                {{ team_member.givenNames }}
                {{ team_member.nameParticle }}
                {{ team_member.familyNames }}
                {{ team_member.nameSuffix }}
            {% endif %}
        {% endfor %}
    </div>
</div>
```