### PR TITLE
Match project tags with the mock up

### DIFF
--- a/frontend/style/templates/_project.scss
+++ b/frontend/style/templates/_project.scss
@@ -49,7 +49,7 @@
             padding: 0.5em 0.8em;
 
             &.bg-light{
-                background-color: darken( $light, 4% );
+                background-color: darken( $light, 20% );
             }
         }
     }

--- a/frontend/templates/project/sidebar.html
+++ b/frontend/templates/project/sidebar.html
@@ -71,7 +71,7 @@
     {% if template_data.tags %}
     <ul class="tags">
         {% for tag in template_data.tags %}
-            <li class="bg-dark">{{tag}}</li>
+            <li class="bg-light">{{tag}}</li>
         {% endfor %}
     </ul>
     {% else %}


### PR DESCRIPTION
Updated the background color of the tags in project pages. See the secreenshot.
Refs: #407 #568 

![image](https://user-images.githubusercontent.com/144492/97308882-a7244b00-1861-11eb-830b-7572fa1c3969.png)
