### PR TITLE
project description can now render as multiple paragraphs

### DIFF
--- a/admin/public/settings.json
+++ b/admin/public/settings.json
@@ -330,6 +330,7 @@
         },
         "description": {
           "help": "Project description",
+          "multiline": true,
           "sortIndex": 200
         },
         "grantId": {


### PR DESCRIPTION
With this PR, the description can render as multiple paragraphs, like so:

![multiline-description-project-page-abc-muse](https://user-images.githubusercontent.com/4558105/97451842-7234f880-1934-11eb-9e2b-a408af34ee8f.png)

Of course, the description should then also include double linebreaks, which this PR doesn't add.