### PR TITLE
revamped the status bar element and removed svg icon from Tags in sidebar

### DIFF
--- a/frontend/style/templates/_project.scss
+++ b/frontend/style/templates/_project.scss
@@ -53,6 +53,10 @@
             }
         }
     }
+    .status_word {
+        margin-left: auto;
+        margin-right: auto;
+    }
 }
 
 .contributor_email .icon {
@@ -63,14 +67,23 @@
 }
 
 .progress_bar {
-    border: 1px solid darken( $light, 30% );
     background-color: darken( $light, 10% );
+    border-radius: 0.25em;
+    border: none;
+    height: 0.5em;
+    margin-bottom: 1em;
     margin-top: 0.7em;
+    margin-left: auto;
+    margin-right: auto;
+    width: 60%;
 }
 
 .progress_bar .progress {
-    height: 0.66em;
     background-color: $primaryColor;
+    border-radius: 0.25em;
+    height: 0.5em;
+    justify-content: space-between;
+    width: 75%;
 }
 
 .time_span {

--- a/frontend/style/templates/_project.scss
+++ b/frontend/style/templates/_project.scss
@@ -54,8 +54,8 @@
         }
     }
     .status_word {
-        margin-left: auto;
-        margin-right: auto;
+        text-align: center;
+        font-size: smaller;
     }
 }
 
@@ -75,7 +75,7 @@
     margin-top: 0.7em;
     margin-left: auto;
     margin-right: auto;
-    width: 60%;
+    width: 70%;
 }
 
 .progress_bar .progress {
@@ -89,7 +89,6 @@
 .time_span {
     display: flex;
     justify-content: space-between;
-    padding-top: 1rem;
     font-size:smaller;
 }
 

--- a/frontend/templates/project/sidebar.html
+++ b/frontend/templates/project/sidebar.html
@@ -5,20 +5,13 @@
 </div>
 <div class="status">
     <h5>Status</h5>
-    <span>{{status.status}}</span>
     <div class="time_span">
         <div>
-            <div>
-                Start date
-            </div>
             <div>
                 {{template_data.dateStart | human_date_month_filter }}
             </div>
         </div>
         <div class="end_date">
-            <div>
-                End date
-            </div>
             <div>
                 {{template_data.dateEnd | human_date_month_filter }}
             </div>
@@ -27,6 +20,7 @@
     <div class="progress_bar" style="">
         <div class="progress" style="width:{{status.progress*100}}%;"></div>
     </div>
+    <div class="status_word">{{status.status}}</div>
 </div>
 <div class="partners">
     <h5>Partners</h5>
@@ -67,7 +61,7 @@
     </ul>
 </div>
 <div class="tags_container">
-    <h5><svg class="icon"><use xlink:href="{{url_for('static', filename='icons/icons.svg')}}#icon-tag"></use></svg>Tags</h5>
+    <h5>Tags</h5>
     {% if template_data.tags %}
     <ul class="tags">
         {% for tag in template_data.tags %}

--- a/frontend/templates/project/sidebar.html
+++ b/frontend/templates/project/sidebar.html
@@ -1,10 +1,16 @@
+{% set show_fund = "FIXME" not in template_data.callUrl and "FIXME" not in template_data.grantId %}
+{% if show_fund %}
 <div class="fund">
     <h5>Funded under</h5>
     <a href="{{ template_data.callUrl }}" target="_blank">TODO call label  <svg class="icon"><use xlink:href="{{url_for('static', filename='icons/icons.svg')}}#icon-external"></use></svg></a>
     <div class="grant">Grant ID: {{ template_data.grantId }}</div>
 </div>
+{% endif %}
 <div class="status">
     <h5>Status</h5>
+    <div class="progress_bar" >
+        <div class="progress" style="width:{{status.progress*100}}%;"></div>
+    </div>
     <div class="time_span">
         <div>
             <div>
@@ -16,9 +22,6 @@
                 {{template_data.dateEnd | human_date_month_filter }}
             </div>
         </div>
-    </div>
-    <div class="progress_bar" style="">
-        <div class="progress" style="width:{{status.progress*100}}%;"></div>
     </div>
     <div class="status_word">{{status.status}}</div>
 </div>


### PR DESCRIPTION
(refs #598, #599, #603, #600)

- progress bar narrower
- removed "start date", "end date" strings
- removed Tags svg icon
- made 'funded under' element conditional

Also finetuned the general appearance of the progress bar element and its children. The result looks like this now:
![sidebar-hidden-fund-emelent-revamped-progress-bar](https://user-images.githubusercontent.com/4558105/97462389-f0969800-193e-11eb-8c64-5304e2daf33d.png)


