### PR TITLE
reduce gap between impact and output (#594)

### DIFF
--- a/frontend/style/templates/_project.scss
+++ b/frontend/style/templates/_project.scss
@@ -153,3 +153,13 @@ figure figcaption {
     font-size: smaller;
     padding-bottom: 10px;
 }
+
+// Mentions section:
+#mentions .container {
+    padding-top: 40px;
+    padding-bottom: 40px;
+    #output_row, #impact_row {
+        padding-top: 25px;
+        padding-bottom: 25px;
+    }
+}

--- a/frontend/templates/project/outputimpact.html
+++ b/frontend/templates/project/outputimpact.html
@@ -1,8 +1,8 @@
-{% if template_data.output %}
+{% if template_data.output or template_data.impact %}
 <section class="bg-dark" id="mentions">
     <div class="container">
-
-        <div class="row">
+        {% if template_data.output %}
+        <div class="row" id="output_row">
             <div class="col-1-4">
                 <h2 class="subtitle">Output</h2>
             </div>
@@ -67,16 +67,9 @@
                 {% endfor %}
             </div>
         </div>
-
-
-    </div>
-</section>
-{% endif %}
-{% if template_data.impact %}
-<section class="bg-dark" id="mentions">
-    <div class="container">
-
-        <div class="row">
+        {% endif %}
+        {% if template_data.impact %}
+        <div class="row" id="impact_row">
             <div class="col-1-4">
                 <h2 class="subtitle">Impact</h2>
             </div>
@@ -141,8 +134,7 @@
                 {% endfor %}
             </div>
         </div>
-
-
+        {% endif %}
     </div>
 </section>
 {% endif %}


### PR DESCRIPTION
Reduces gap between impact and output sections (refs #594)
Should look nice if there are 

1. both impact and output
2. neither impact nor output
3. impact or output

How to test?
1 can be tested by looking at ABC-muse
3 for any other project
2 doesn't exist so hard to test. You can fake this by hiding the appropriate html tags. See the outputimpact.html for the logic and see if it still looks ok.