### PR TITLE
attempt to better balance logo sizes

### DIFF
--- a/frontend/style/templates/_project.scss
+++ b/frontend/style/templates/_project.scss
@@ -50,7 +50,12 @@
 
 .organisation {
     img {
-        width: 100%;
+        width: 80%;
+        margin-left: auto;
+        margin-right: auto;
+        padding-top: 10px;
+        padding-bottom: 10px;
+        display: block;
     }
 }
 

--- a/frontend/style/templates/_project.scss
+++ b/frontend/style/templates/_project.scss
@@ -48,6 +48,12 @@
     }
 }
 
+.organisation {
+    img {
+        width: 100%;
+    }
+}
+
 .progress_bar {
     background-color: darken( $light, 10% );
     border-radius: 0.25em;


### PR DESCRIPTION
Not the prettiest of results, but I think it's the best I can do for now. Please see my comment in #597 for an explanation before reviewing this PR.
Shortcomings:
- a combination of very wide and very narrow logos will look terrible
- low-resolution logos can look pixelated as they will be enlarged to fit the width of the sidebar whether they like it or not (this is already the case a bit for the Utrecht logo)