### PR TITLE
Make project page more responsive

### DIFF
--- a/frontend/templates/project/introduction.html
+++ b/frontend/templates/project/introduction.html
@@ -10,7 +10,7 @@
             <div class="col col-3-4">
                 <figure>
                     <img src="{{ template_data.imageUrl }}"
-                         onerror="this.src='/static/icons/white-square.png'; this.onerror='';" height=30%>
+                         onerror="this.src='/static/icons/white-square.png'; this.onerror='';">
                     {% if template_data.imageCaption %}
                     <figcaption>{{ template_data.imageCaption }}</figcaption>
                     {% endif %}


### PR DESCRIPTION
Refs #596

Did not center text of team on narrow screen as it still looks OK and is inline with the section headers.