### PR TITLE
Reload data after resource is created/updated/deleted

### DIFF
--- a/admin/src/components/Resource/EmptyResource.tsx
+++ b/admin/src/components/Resource/EmptyResource.tsx
@@ -27,6 +27,7 @@ interface IConnectedProps {
   push(location: any): any;
   messageToastr(message: string): any;
   errorToastr(message: string): any;
+  resourceUpdated(): any;
 }
 
 interface IState {
@@ -91,6 +92,7 @@ export class EmptyResource extends React.PureComponent<IProps, IState> {
       })
       .then(response => {
         this.setState({ saving: false });
+        this.props.resourceUpdated();
         if (response.status === 200) {
           this.props.messageToastr("Saved");
           const id = response.data.primaryKey.id;

--- a/admin/src/components/Resource/index.tsx
+++ b/admin/src/components/Resource/index.tsx
@@ -19,6 +19,7 @@ interface IConnectedProps {
   push(location: any): any;
   messageToastr(message: string): any;
   errorToastr(message: string): any;
+  resourceUpdated(): any;
 }
 
 type IProps = IConnectedProps &
@@ -46,6 +47,7 @@ class DeleteModal extends React.PureComponent<
       .then(() => {
         this.setState({ modalOpen: false, links: [], error: null });
         this.props.messageToastr("Deleted");
+        this.props.resourceUpdated();
       })
       .catch(response => {
         const result = response.response;
@@ -146,6 +148,7 @@ export default class Resource extends React.PureComponent<IProps, IState> {
       .then(() => {
         this.setState({ saving: false });
         this.props.messageToastr("Saved");
+        this.props.resourceUpdated();
       })
       .catch(response => {
         this.setState({ saving: false });
@@ -178,6 +181,7 @@ export default class Resource extends React.PureComponent<IProps, IState> {
       }
     });
     await this.asyncSetState({ data: result.data, loading: false });
+
   }
 
   async componentDidMount() {

--- a/admin/src/containers/Resource/EmptyResource.tsx
+++ b/admin/src/containers/Resource/EmptyResource.tsx
@@ -28,6 +28,9 @@ const dispatchToProps = {
       position: "top-center",
       title: "Message",
       type: "info"
+    }),
+    resourceUpdated: () => ({
+       type: "DATA_FETCH_REQUESTED"
     })
 };
 

--- a/admin/src/containers/Resource/index.tsx
+++ b/admin/src/containers/Resource/index.tsx
@@ -28,7 +28,10 @@ const dispatchToProps = {
       position: "top-center",
       title: "Message",
       type: "info"
-    })
+    }),
+  resourceUpdated: () => ({
+     type: "DATA_FETCH_REQUESTED"
+  })
 };
 
 export default connect(mapStateToProps, dispatchToProps)(Resource);

--- a/admin/src/saga.ts
+++ b/admin/src/saga.ts
@@ -3,7 +3,7 @@
  * @todo Scenario where JWT is invalid
  */
 
-import { put, call, select, all } from "redux-saga/effects";
+import { put, call, select, all, takeLatest } from "redux-saga/effects";
 import fetch, { AxiosRequestConfig } from "axios";
 import { actions as toastrActions } from "react-redux-toastr";
 import { push } from "react-router-redux";
@@ -136,6 +136,7 @@ function* initSaga() {
     yield call(getJWT(settings.authUrl));
     yield all([call(fetchData), call(fetchSchema)]);
     yield put({ type: "INIT_DONE" });
+    yield takeLatest("DATA_FETCH_REQUESTED", fetchData);
   } catch (e) {
     if (e.message === "Network Error") {
       yield put(errorAction("Network error connecting to " + e.config.url));


### PR DESCRIPTION
Allows administrator to add/update/delete a resource and then connect it to another resource resource without having to reload page.

Refs #334 and fixes #638 

This will add an extra heavy request on each save, but I think it is worth it to skip page reload.