### PR TITLE
Update data-migration-2.0.x-to-2.1.x.js

### DIFF
--- a/data-migration/data-migration-2.0.x-to-2.1.x.js
+++ b/data-migration/data-migration-2.0.x-to-2.1.x.js
@@ -10,8 +10,8 @@ const update = {
   $set: {
     callUrl: 'https://doi.org/FIXME',
     codeUrl: 'https://github.com/FIXME',
-    dateEnd: '1901-01-01T00:00:00Z',
-    dateStart: '1900-01-01T00:00:00Z',
+    dateEnd: '1901-01-01',
+    dateStart: '1900-01-01',
     description: 'FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME',
     grantId: 'FIXME',
     isPublished: true,


### PR DESCRIPTION
This PR changes how project's `dateStart` and `dateEnd` are initialized. 

Refs: #622, #635

I think this means we no longer need https://github.com/research-software-directory/research-software-directory/blob/master/data-migration/data-migration-project-date.js

