### PR TITLE
Vuetify project index page

### DIFF
--- a/frontend/app/application.py
+++ b/frontend/app/application.py
@@ -258,6 +258,7 @@ def project_index_template():
                        "yearEnd": get_year_from_date_string(project["dateEnd"])})
 
     return flask.render_template('project/project_index.html',
+                                 data_json=flask.Markup(json.dumps(titles)),
                                  titles=titles)
 
 

--- a/frontend/app/application.py
+++ b/frontend/app/application.py
@@ -248,9 +248,9 @@ def get_year_from_date_string(date_string):
 def project_index_template():
     url = api_url + "/project_cache"
     project_data = requests.get(url).json()
-    titles = []
+    projects = []
     for project in project_data:
-        titles.append({"id": project["primaryKey"]["id"],
+        projects.append({"id": project["primaryKey"]["id"],
                        "title": project["title"],
                        "subtitle": project["subtitle"],
                        "imageUrl": project["imageUrl"],
@@ -258,8 +258,8 @@ def project_index_template():
                        "yearEnd": get_year_from_date_string(project["dateEnd"])})
 
     return flask.render_template('project/project_index.html',
-                                 data_json=flask.Markup(json.dumps(titles)),
-                                 titles=titles)
+                                 data_json=flask.Markup(json.dumps(projects)),
+                                 projects=projects)
 
 
 @application.route('/about')

--- a/frontend/static/scripts/project_index_scripts.js
+++ b/frontend/static/scripts/project_index_scripts.js
@@ -20,7 +20,7 @@ function initOverview(projectsData) {
     }
 
     var v = new Vue({
-        el: '#projects_page',
+        el: '#project_index_page',
         delimiters: ["[[", "]]"],
         methods: {
             log: console.log,

--- a/frontend/static/scripts/projects_scripts.js
+++ b/frontend/static/scripts/projects_scripts.js
@@ -1,0 +1,87 @@
+/* projects_scripts.js
+ * This file runs on top of the software overview page (templates/project/project_index.html).
+ * It is served as-is, so please keep everything ES5 compatible.
+*/
+
+/*** Copyright 2013 Teun Duynstee Licensed under the Apache License, Version 2.0 ***/
+var firstBy=function(){function n(n){return n}function t(n){return"string"==typeof n?n.toLowerCase():n}function r(r,e){if(e="number"==typeof e?{direction:e}:e||{},"function"!=typeof r){var i=r;r=function(n){return n[i]?n[i]:""}}if(1===r.length){var u=r,o=e.ignoreCase?t:n;r=function(n,t){return o(u(n))<o(u(t))?-1:o(u(n))>o(u(t))?1:0}}return-1===e.direction?function(n,t){return-r(n,t)}:r}function e(n,t){var i="function"==typeof this&&this,u=r(n,t),o=i?function(n,t){return i(n,t)||u(n,t)}:u;return o.thenBy=e,o}return e}();
+/*** https://github.com/component/debounce ***/
+function debounce(n,l,u){function t(){var c=Date.now()-r;c<l&&c>=0?e=setTimeout(t,l-c):(e=null,u||(i=n.apply(o,a),o=a=null))}var e,a,o,r,i;null==l&&(l=100);var c=function(){o=this,a=arguments,r=Date.now();var c=u&&!e;return e||(e=setTimeout(t,l)),c&&(i=n.apply(o,a),o=a=null),i};return c.clear=function(){e&&(clearTimeout(e),e=null)},c.flush=function(){e&&(i=n.apply(o,a),o=a=null,clearTimeout(e),e=null)},c}
+
+function initOverview(projectsData) {
+    var device = {
+        phone: 'phone',
+        tablet: 'tablet',
+        desktop: 'desktop'
+    };
+
+    function getDevice() {
+        return window.innerWidth > 1000 ? device.desktop : (window.innerWidth > 700 ? device.tablet : device.phone);
+    }
+
+    var v = new Vue({
+        el: '#projects_page',
+        delimiters: ["[[", "]]"],
+        methods: {
+            log: console.log,
+            showPage: function (n) {
+                return n === 1 || n === this.lastPage || Math.abs(n - this.page) <= 2
+            }
+        },
+        data: {
+            device: getDevice(),
+            page: 1,
+            projects: projectsData,
+            mobShowFilters: false
+        },
+        computed: {
+            filteredProjects: function () {
+                // TODO apply filters
+                return this.projects;
+            },
+            sortedProjects: function () {
+                // TODO implement sort
+                return this.filteredProjects;
+            },
+            pagedProjects: function () {
+                var offset = this.pageSize * (this.page - 1);
+                return this.sortedProjects.slice(offset, offset + this.pageSize);
+            },
+
+            lastPage: function () {
+                return Math.ceil(this.filteredProjects.length / this.pageSize);
+            },
+
+            pageSize: function() {
+                return {
+                    phone: 5,
+                    tablet: 10,
+                    desktop: 10
+                }[this.device];
+            }
+        },
+        watch: {
+            page: {
+                handler: function () { window.scrollTo(0,0); }
+            },
+            pageSize: {
+                handler: function () { this.page = 1; }
+            }
+        }
+    });
+    window.v = v;
+    window.addEventListener('resize', debounce(function(event) {
+        v.device = getDevice();
+    }, 200));
+}
+
+// Beamer Mode | Press 'Ctrl + b' to darken the grey backgrounds
+// ---------------------------------------------------------------------
+function KeyPress(e) {
+    var bodyel = document.querySelector('body');
+    var evtobj = window.event? event : e
+    if (evtobj.keyCode == 66 && evtobj.ctrlKey){
+        bodyel.classList.toggle('beamer-mode');
+    }
+}
+document.onkeydown = KeyPress;

--- a/frontend/style/templates/_project.scss
+++ b/frontend/style/templates/_project.scss
@@ -550,7 +550,7 @@
   // Related projects
   // -----------------------------------
 
-  #related-projects {
+  #related-projects, #projects-container {
     .container {
       padding-top: 65px;
       padding-bottom: 65px;

--- a/frontend/style/templates/_project.scss
+++ b/frontend/style/templates/_project.scss
@@ -1,4 +1,4 @@
-#project_page, #projects_page {
+#project_page, #project_index_page {
 
   // Common
   // -----------------------------------

--- a/frontend/style/templates/_project.scss
+++ b/frontend/style/templates/_project.scss
@@ -1,4 +1,4 @@
-#project_page {
+#project_page, #projects_page {
 
   // Common
   // -----------------------------------

--- a/frontend/templates/project/project_index.html
+++ b/frontend/templates/project/project_index.html
@@ -4,7 +4,7 @@
 <title>Projects | Research Software Directory</title>
 {%- endblock -%}
 {%- block content -%}
-<div id="project_page">
+<div id="projects_page">
 	<section class="" id="title">
 		<div class="container">
 			<div class="row">
@@ -16,28 +16,82 @@
 		</div>
 	</section>
 
-	<section class="" id="related-projects">
+    <noscript>
+		<div id="noscript_projects" class="row">
+		  {%- for title in (titles  | sort(attribute="title")) -%}
+			<li class="col-1-4">
+			  <a href="/projects/{{ title.id }}">{{ title.title }}</a>
+			</li>
+		  {%- endfor -%}
+		</div>
+	  </noscript>
+
+	<section class="" id="related-projects" v-cloak>
 		<div class="container">
 			<div class="row">
-				<div class="col-1-1">
-					<div class="row project-items">
-						{% for title in (titles  | sort(attribute="title")) %}
-						<article class="project-item col-1-2"><a href="/projects/{{ title.id }}">
+				<div class="col-1-4" id="filters">
+					<div class="filters_container" :class="{ 'mob-hidden' : !mobShowFilters }">
+						{# TODO add filters #}
+					</div>
+
+					<div class="toggle-filters" @click="mobShowFilters = !mobShowFilters">
+						<span class="icon">[[ mobShowFilters ? '-' : '+' ]]</span>
+						<span class="text">[[ mobShowFilters ? 'Hide filters' : 'Show filters' ]]</span>
+					</div>
+				</div>
+				<div class="col-3-4" id="project_list">
+					<transition-group appear name="slide-fade" tag="div" class="row project-items">
+						<article v-for="project in pagedProjects" v-bind:key="project" class="project-item col-1-2">
+							<a :href="'/projects/' + (project.id)">
 								<div class="content">
-									<div class="thumb"><img src="{{title.imageUrl}}" alt=""></div>
+									<div class="thumb">
+										<img :src="project.imageUrl" alt="">
+									</div>
 									<div class="text">
-										<p class="text-blue">{{ title.title }}
-											({{ title.yearStart }}{% if title.yearStart != title.yearEnd %}-{{ title.yearEnd }}{% endif %})
-										</p>
-										<p>{{title.subtitle}}</p>
+										<p class="text-blue">[[project.title]]</p>
+										<p>[[project.subtitle]]</p>
 									</div>
 								</div>
-							</a></article>
-						{% endfor %}
+							</a>
+						</article>
+					</transition-group>
+
+					<div v-if="pagedProjects.length === 0">
+						No results for <i>[[ filter.search ]]</i>
 					</div>
+
+					<div class="pagination" v-else>
+						<span @click="page = page > 1 ? page - 1 : page">
+						  &lt;
+						</span>
+
+						<template v-for="i in lastPage">
+						  <span
+							v-if="showPage(i)"
+							@click="page = i"
+							:class="{ active: page === i }"
+						  >
+							[[ i ]]
+						  </span>
+						  <span class="gap" v-else-if="i !== lastPage && showPage(i-1)">
+							...
+						  </span>
+						</template>
+
+						<span @click="page = page < lastPage ? page + 1 : page">
+						  &gt;
+						</span>
+
+					  </div>
 				</div>
 			</div>
 		</div>
 	</section>
 </div>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.9/vue.min.js" crossorigin="anonymous"></script>
+<script type="text/javascript" src="{{url_for('static', filename='scripts/polyfills.js') }}"></script>
+<script type="text/javascript" src="{{url_for('static', filename='scripts/projects_scripts.js') }}"></script>
+<script>
+	initOverview({{data_json}});
+</script>
 {%- endblock -%}

--- a/frontend/templates/project/project_index.html
+++ b/frontend/templates/project/project_index.html
@@ -5,93 +5,93 @@
 {%- endblock -%}
 {%- block content -%}
 <div id="projects_page">
-	<section class="" id="title">
-		<div class="container">
-			<div class="row">
-				<div class="text">
-					<h1 class="title">Projects</h1>
-					<p>This list of projects of the Netherlands eScience Center contains {{titles|length}} projects</p>
-				</div>
-			</div>
-		</div>
-	</section>
+  <section class="" id="title">
+    <div class="container">
+      <div class="row">
+        <div class="text">
+          <h1 class="title">Projects</h1>
+          <p>This list of projects of the Netherlands eScience Center contains {{titles|length}} projects</p>
+        </div>
+      </div>
+    </div>
+  </section>
 
-    <noscript>
-		<div id="noscript_projects" class="row">
-		  {%- for title in (titles  | sort(attribute="title")) -%}
-			<li class="col-1-4">
-			  <a href="/projects/{{ title.id }}">{{ title.title }}</a>
-			</li>
-		  {%- endfor -%}
-		</div>
-	  </noscript>
+  <noscript>
+    <div id="noscript_projects" class="row">
+      {%- for title in (titles  | sort(attribute="title")) -%}
+      <li class="col-1-4">
+        <a href="/projects/{{ title.id }}">{{ title.title }}</a>
+      </li>
+      {%- endfor -%}
+    </div>
+    </noscript>
 
-	<section class="" id="related-projects" v-cloak>
-		<div class="container">
-			<div class="row">
-				<div class="col-1-4" id="filters">
-					<div class="filters_container" :class="{ 'mob-hidden' : !mobShowFilters }">
-						{# TODO add filters #}
-					</div>
+  <section class="" id="related-projects" v-cloak>
+    <div class="container">
+      <div class="row">
+        <div class="col-1-4" id="filters">
+          <div class="filters_container" :class="{ 'mob-hidden' : !mobShowFilters }">
+            {# TODO add filters #}
+          </div>
 
-					<div class="toggle-filters" @click="mobShowFilters = !mobShowFilters">
-						<span class="icon">[[ mobShowFilters ? '-' : '+' ]]</span>
-						<span class="text">[[ mobShowFilters ? 'Hide filters' : 'Show filters' ]]</span>
-					</div>
-				</div>
-				<div class="col-3-4" id="project_list">
-					<transition-group appear name="slide-fade" tag="div" class="row project-items">
-						<article v-for="project in pagedProjects" v-bind:key="project" class="project-item col-1-2">
-							<a :href="'/projects/' + (project.id)">
-								<div class="content">
-									<div class="thumb">
-										<img :src="project.imageUrl" alt="">
-									</div>
-									<div class="text">
-										<p class="text-blue">[[project.title]]</p>
-										<p>[[project.subtitle]]</p>
-									</div>
-								</div>
-							</a>
-						</article>
-					</transition-group>
+          <div class="toggle-filters" @click="mobShowFilters = !mobShowFilters">
+            <span class="icon">[[ mobShowFilters ? '-' : '+' ]]</span>
+            <span class="text">[[ mobShowFilters ? 'Hide filters' : 'Show filters' ]]</span>
+          </div>
+        </div>
+        <div class="col-3-4" id="project_list">
+          <transition-group appear name="slide-fade" tag="div" class="row project-items">
+            <article v-for="project in pagedProjects" v-bind:key="project" class="project-item col-1-2">
+              <a :href="'/projects/' + (project.id)">
+                <div class="content">
+                  <div class="thumb">
+                    <img :src="project.imageUrl" alt="">
+                  </div>
+                  <div class="text">
+                    <p class="text-blue">[[project.title]]</p>
+                    <p>[[project.subtitle]]</p>
+                  </div>
+                </div>
+              </a>
+            </article>
+          </transition-group>
 
-					<div v-if="pagedProjects.length === 0">
-						No results for <i>[[ filter.search ]]</i>
-					</div>
+          <div v-if="pagedProjects.length === 0">
+            No results for <i>[[ filter.search ]]</i>
+          </div>
 
-					<div class="pagination" v-else>
-						<span @click="page = page > 1 ? page - 1 : page">
-						  &lt;
-						</span>
+          <div class="pagination" v-else>
+            <span @click="page = page > 1 ? page - 1 : page">
+              &lt;
+            </span>
 
-						<template v-for="i in lastPage">
-						  <span
-							v-if="showPage(i)"
-							@click="page = i"
-							:class="{ active: page === i }"
-						  >
-							[[ i ]]
-						  </span>
-						  <span class="gap" v-else-if="i !== lastPage && showPage(i-1)">
-							...
-						  </span>
-						</template>
+            <template v-for="i in lastPage">
+              <span
+              v-if="showPage(i)"
+              @click="page = i"
+              :class="{ active: page === i }"
+              >
+              [[ i ]]
+              </span>
+              <span class="gap" v-else-if="i !== lastPage && showPage(i-1)">
+              ...
+              </span>
+            </template>
 
-						<span @click="page = page < lastPage ? page + 1 : page">
-						  &gt;
-						</span>
+            <span @click="page = page < lastPage ? page + 1 : page">
+              &gt;
+            </span>
 
-					  </div>
-				</div>
-			</div>
-		</div>
-	</section>
+            </div>
+        </div>
+      </div>
+    </div>
+  </section>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.9/vue.min.js" crossorigin="anonymous"></script>
 <script type="text/javascript" src="{{url_for('static', filename='scripts/polyfills.js') }}"></script>
 <script type="text/javascript" src="{{url_for('static', filename='scripts/projects_scripts.js') }}"></script>
 <script>
-	initOverview({{data_json}});
+  initOverview({{data_json}});
 </script>
 {%- endblock -%}

--- a/frontend/templates/project/project_index.html
+++ b/frontend/templates/project/project_index.html
@@ -10,7 +10,7 @@
       <div class="row">
         <div class="text">
           <h1 class="title">Projects</h1>
-          <p>This list of projects of the Netherlands eScience Center contains {{titles|length}} projects</p>
+          <p>This list of projects of the Netherlands eScience Center contains {{projects|length}} projects</p>
         </div>
       </div>
     </div>
@@ -18,7 +18,7 @@
 
   <noscript>
     <div id="noscript_projects" class="row">
-      {%- for title in (titles  | sort(attribute="title")) -%}
+      {%- for title in (projects  | sort(attribute="title")) -%}
       <li class="col-1-4">
         <a href="/projects/{{ title.id }}">{{ title.title }}</a>
       </li>

--- a/frontend/templates/project/project_index.html
+++ b/frontend/templates/project/project_index.html
@@ -26,7 +26,7 @@
     </div>
     </noscript>
 
-  <section class="" id="related-projects" v-cloak>
+  <section class="" id="projects-container" v-cloak>
     <div class="container">
       <div class="row">
         <div class="col-1-4" id="filters">
@@ -90,7 +90,7 @@
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.9/vue.min.js" crossorigin="anonymous"></script>
 <script type="text/javascript" src="{{url_for('static', filename='scripts/polyfills.js') }}"></script>
-<script type="text/javascript" src="{{url_for('static', filename='scripts/projects_scripts.js') }}"></script>
+<script type="text/javascript" src="{{url_for('static', filename='scripts/project_index_scripts.js') }}"></script>
 <script>
   initOverview({{data_json}});
 </script>

--- a/frontend/templates/project/project_index.html
+++ b/frontend/templates/project/project_index.html
@@ -4,7 +4,7 @@
 <title>Projects | Research Software Directory</title>
 {%- endblock -%}
 {%- block content -%}
-<div id="projects_page">
+<div id="project_index_page">
   <section class="" id="title">
     <div class="container">
       <div class="row">


### PR DESCRIPTION
Refs #662

Changes project index page from being rendered on the Python server side to being rendered with VueJS in the browser.
* Adds paging
* Filters container is already there with some TODO placeholders

<details>
  <summary>Screenshot</summary>
 
![localhost_projects_](https://user-images.githubusercontent.com/1713488/99555354-81054d00-29c0-11eb-91a1-e8cd3e9a43a9.png)

</details>

## Checklist for the contributor

* [x] Changes tested (self-review)
  * When going to another page of projects the page jumps down and up, think this will disappear when page is more fleshed out
* [x] CI checks (all green)
* [x] Documentation is up to date

## Instructions to review the pull request

To review the frontend should be re-build with 

```shell
docker-compose build frontend
docker-compose up
```

The https://localhost/projects/ page should show a list of projects with paging controls at the bottom.