### PR TITLE
fixed broken link

### DIFF
--- a/frontend/templates/footer_template.html
+++ b/frontend/templates/footer_template.html
@@ -23,7 +23,7 @@
                 <ul>
                     <li><a href="https://www.esciencecenter.nl">Home</a></li>
                     <li><a href="/projects">Projects</a></li>
-                    <li><a href="https://www.esciencecenter.nl/people">People</a></li>
+                    <li><a href="https://www.esciencecenter.nl/about/#content">People</a></li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
The corporate site has removed its `/people` route, the closest thing is now `/about` and then scroll down to the `content` section. This PR updates that hyperlink.

Refs #665 