### PR TITLE
Dont set `$unset` when there is nothing to unset.

### DIFF
--- a/backend/src/routes.py
+++ b/backend/src/routes.py
@@ -10,7 +10,7 @@ from jsonschema import validate
 from src import exceptions
 from src.json_response import jsonify
 from src.permission import get_sub, require_permission
-from src.util import resource2update, find_data_links
+from src.util import find_data_links, resource2update
 
 
 def time_now():

--- a/backend/src/routes.py
+++ b/backend/src/routes.py
@@ -10,7 +10,7 @@ from jsonschema import validate
 from src import exceptions
 from src.json_response import jsonify
 from src.permission import get_sub, require_permission
-from src.util import field2unset, find_data_links
+from src.util import resource2update, find_data_links
 
 
 def time_now():
@@ -191,9 +191,9 @@ def get_routes(db, schemas):
             for resource in resources_to_create:
                 db[resource_type].insert(resource)
             for resource in resources_to_update:
-                fields2remove = field2unset(schemas[resource_type], resource)
+                update = resource2update(schemas[resource_type], resource)
                 db[resource_type].update_one({'_id': resource['_id']},
-                                             {'$set': resource, '$unset': fields2remove})
+                                             update)
 
         return {"ok": True}, 200
 
@@ -240,9 +240,9 @@ def get_routes(db, schemas):
         data['_id'] = resource_id
 
         if 'test' not in flask.request.args:
-            fields2remove = field2unset(schemas[resource_type], data)
+            update = resource2update(schemas[resource_type], data)
             db[resource_type].update_one({'_id': resource_id},
-                                         {'$set': data, '$unset': fields2remove})
+                                         update)
 
         if 'save_history' in flask.request.args:
             old_data.pop('_id')

--- a/backend/src/util.py
+++ b/backend/src/util.py
@@ -110,6 +110,16 @@ def find_data_links(db, schemas, resource_type, id):
 
     return data_links
 
+def resource2update(schema, resource):
+    """Generates update variable for MongoDB update_one(filter, update)
+
+    """
+    update = {'$set': resource}
+    fields2remove = field2unset(schema, resource)
+    if fields2remove:
+        update['$unset'] = fields2remove
+    return update
+
 def field2unset(schema, data):
     """"Fields which are optional and missing in request data should be unset
     """

--- a/backend/tests/unit/test_utils.py
+++ b/backend/tests/unit/test_utils.py
@@ -28,3 +28,60 @@ def test_field2unset():
     fields = util.field2unset(schema, resource)
 
     assert fields == {'opt': ''}
+
+def test_resource2update_one2unset():
+    schema = {
+        'properties': {
+            '_id': None,
+            'opt': None
+        },
+        'required': ['_id']
+    }
+    resource = {
+        '_id': 'foo'
+    }
+    fields = util.resource2update(schema, resource)
+
+    expected = {
+        '$set': {'_id': 'foo'},
+        '$unset': {'opt': ''}
+    }
+    assert fields == expected
+
+def test_resource2update_nothing2unset():
+    schema = {
+        'properties': {
+            '_id': None,
+        },
+        'required': ['_id']
+    }
+    resource = {
+        '_id': 'foo'
+    }
+    fields = util.resource2update(schema, resource)
+
+    expected = {
+        '$set': {'_id': 'foo'}
+    }
+    assert fields == expected
+
+def test_resource2update_keepopt():
+    schema = {
+        'properties': {
+            '_id': None,
+            'opt1': None,
+            'opt2': None
+        },
+        'required': ['_id']
+    }
+    resource = {
+        '_id': 'foo',
+        'opt2': 'bar'
+    }
+    fields = util.resource2update(schema, resource)
+
+    expected = {
+        '$set': {'_id': 'foo', 'opt2': 'bar'},
+        '$unset': {'opt1': ''}
+    }
+    assert fields == expected


### PR DESCRIPTION
Refs #651

This PR resolves the `'$unset' is empty` error.

To review
1. Rebuild backend service with `docker-compose build backend`
1. Goto admin
1. Goto a project
1. Set dataManagementPlanUrl to https://doi.org/fixme
1. Set softwareSustainabilityPlanUrl to empty
1. Press save

The save should be successful. 
To review further the values of dataManagementPlanUrl and softwareSustainabilityPlanUrl can be swapped around or all filled or all empty.