### PR TITLE
reset form string fields to empty string

### DIFF
--- a/admin/src/components/Form/TypeObject.tsx
+++ b/admin/src/components/Form/TypeObject.tsx
@@ -8,7 +8,7 @@ export default class TypeObject extends React.Component<IProps<IObjectSchema>> {
   handleChange = (key: string) => (value: any) => {
     if (isStringSchema(this.props.schema.properties[key]) && value === "") {
       const cpy = { ...this.props.value };
-      delete cpy[key];
+      cpy[key] = "";
       this.props.onChange(cpy);
       return;
     }


### PR DESCRIPTION
# Pull request details

In form fields in the admin interface, string fields are emptied before updates to make it possible for a user to clear the field. The code performs this action by deleting the field which changes the field value to undefined. When this happens, the type of the field changes from string to object. Since error handling depends on field type, this results in inconsistent error messages for empty string fields in forms. This problem can be solved by setting the string fields to empty strings instead of deleting them.

## List of related issues or pull requests

Refs: #341 

## Describe the changes made in this pull request

Instead of deleting updated string fields in forms, set them to empty string.

## Instructions to review the pull request

Test this PR by performing the following two actions before and after the update:

1. in the person section of the admin interface, create a new person (+). Under the field givenNames, there will be an error message about the length of the name. Enter some text in the field and then remove all of it. Before the update, the error message will disappear and stay away. After the update, the message should re-appear when the field becomes empty.
2. in the person section of the admin interface, select a person and remove the text in the field givenNames. After the update, an error message should appear when the field becomes empty.