### PR TITLE
make organization.url optional property

### DIFF
--- a/admin/public/settings.json
+++ b/admin/public/settings.json
@@ -483,6 +483,11 @@
           "label": "Updated by",
           "readonly": true,
           "sortIndex": 1004
+        },
+        "url": {
+          "label": "Organization URL",
+          "readonly": false,
+          "sortIndex": 300
         }
       }
     }

--- a/admin/public/settings.json
+++ b/admin/public/settings.json
@@ -483,11 +483,6 @@
           "label": "Updated by",
           "readonly": true,
           "sortIndex": 1004
-        },
-        "url": {
-          "label": "Organization URL",
-          "readonly": false,
-          "sortIndex": 300
         }
       }
     }

--- a/backend/schemas/organization.json
+++ b/backend/schemas/organization.json
@@ -26,10 +26,6 @@
         },
         "updatedBy": {
             "type": "string"
-        },
-        "url": {
-            "format": "uri",
-            "type": "string"
         }
     },
     "required": [
@@ -37,8 +33,7 @@
         "logo",
         "name",
         "primaryKey",
-        "updatedAt",
-        "url"
+        "updatedAt"
     ],
     "title": "Organization schema"
 }

--- a/backend/schemas/organization.json
+++ b/backend/schemas/organization.json
@@ -26,6 +26,10 @@
         },
         "updatedBy": {
             "type": "string"
+        },
+        "url": {
+            "format": "uri",
+            "type": "string"
         }
     },
     "required": [

--- a/data-migration/2.x-to-3.x/harvest_project_info_nlesc.py
+++ b/data-migration/2.x-to-3.x/harvest_project_info_nlesc.py
@@ -366,7 +366,6 @@ def make_new_organization_data(name_data):
     new_organization_data["createdBy"] = "esciencecenter.nl.crawler"
     new_organization_data["updatedAt"] = new_organization_data["createdAt"]
     new_organization_data["updatedBy"] = new_organization_data["createdBy"]
-    new_organization_data["url"] = "https://FIXME"
     if "name" in name_data:
         new_organization_data["name"] = name_data["name"]
     img_data = ""

--- a/data-migration/2.x-to-3.x/migrate.js
+++ b/data-migration/2.x-to-3.x/migrate.js
@@ -1,91 +1,87 @@
 /* global db */
 
-const migrate_project_collection = () => {
+const migrateProjectCollection = () => {
+  print('migrating project collection...')
 
-    print("migrating project collection...")
+  const query = {}
 
-    const query = {}
-
-    // Note: keys 'dataManagementPlanUrl', 'homeUrl', 'imageCaption', and
-    // 'softwareSustainabilityPlanUrl' are purposely not set, as they are
-    // not required. Users can still set them through the admin
-    // interface if they want though.
-    const update = {
-      $set: {
-        callUrl: 'https://doi.org/FIXME',
-        codeUrl: 'https://github.com/FIXME',
-        dateEnd: '1901-01-01',
-        dateStart: '1900-01-01',
-        description: 'FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME',
-        grantId: 'FIXME',
-        isPublished: true,
-        'related.organizations': [],
-        'related.projects': [],
-        'related.software': [],
-        tags: [],
-        team: []
-      },
-      $rename: {
-        image: 'imageUrl'
-      },
-      $unset: {
-        corporateUrl: '',
-        principalInvestigator: ''
-      }
+  // Note: keys 'dataManagementPlanUrl', 'homeUrl', 'imageCaption', and
+  // 'softwareSustainabilityPlanUrl' are purposely not set, as they are
+  // not required. Users can still set them through the admin
+  // interface if they want though.
+  const update = {
+    $set: {
+      callUrl: 'https://doi.org/FIXME',
+      codeUrl: 'https://github.com/FIXME',
+      dateEnd: '1901-01-01',
+      dateStart: '1900-01-01',
+      description: 'FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME',
+      grantId: 'FIXME',
+      isPublished: true,
+      'related.organizations': [],
+      'related.projects': [],
+      'related.software': [],
+      tags: [],
+      team: []
+    },
+    $rename: {
+      image: 'imageUrl'
+    },
+    $unset: {
+      corporateUrl: '',
+      principalInvestigator: ''
     }
+  }
 
-    db.project.updateMany(query, update)
+  db.project.updateMany(query, update)
 
-    print("migrating project collection...done")
-
+  print('migrating project collection...done')
 }
 
-const migrate_organization_collection = () => {
+const migrateOrganizationCollection = () => {
+  print('migrating organization collection...')
 
-    print("migrating organization collection...")
+  const query = {}
 
-    const query = {}
-
-    const update = {
-      $unset: {
-        url: ''
-      }
+  const update = {
+    $unset: {
+      url: ''
     }
+  }
 
-    db.organization.updateMany(query, update)
+  db.organization.updateMany(query, update)
 
-    print("migrating organization collection...done")
+  print('migrating organization collection...done')
 }
 
+const harmonizeProjectUrls = () => {
+  // Make links to corporate site uniform
+  // - only https links
+  // - no www subdomain to esciencecenter.nl
 
-const harmonize_project_urls = () => {
-    // Make links to corporate site uniform
-    // - only https links
-    // - no www subdomain to esciencecenter.nl
+  print('harmonizing project urls...')
 
-    print("harmonizing project urls...")
+  db.project.find({
+    imageUrl: {
+      $regex: '^http://www.esciencecenter.nl'
+    }
+  }).forEach((doc, idoc) => {
+    doc.imageUrl = doc.imageUrl.replace('http://www.esciencecenter.nl', 'https://esciencecenter.nl')
+    db.project.save(doc)
+  })
 
-    db.project.find({
-      imageUrl: {
-        $regex: '^http://www.esciencecenter.nl'
-      }
-    }).forEach((doc, idoc) => {
-      doc.imageUrl = doc.imageUrl.replace('http://www.esciencecenter.nl', 'https://esciencecenter.nl')
-      db.project.save(doc)
-    })
+  db.project.find({
+    imageUrl: {
+      $regex: '^https://www.esciencecenter.nl'
+    }
+  }).forEach((doc, idoc) => {
+    doc.imageUrl = doc.imageUrl.replace('https://www.esciencecenter.nl', 'https://esciencecenter.nl')
+    db.project.save(doc)
+  })
 
-    db.project.find({
-      imageUrl: {
-        $regex: '^https://www.esciencecenter.nl'
-      }
-    }).forEach((doc, idoc) => {
-      doc.imageUrl = doc.imageUrl.replace('https://www.esciencecenter.nl', 'https://esciencecenter.nl')
-      db.project.save(doc)
-    })
-
-    print("harmonizing project urls...done")
+  print('harmonizing project urls...done')
 }
 
-migrate_project_collection()
-harmonize_project_urls()
-migrate_organization_collection()
+migrateProjectCollection()
+harmonizeProjectUrls()
+migrateOrganizationCollection()

--- a/data-migration/2.x-to-3.x/migrate.js
+++ b/data-migration/2.x-to-3.x/migrate.js
@@ -38,22 +38,6 @@ const migrateProjectCollection = () => {
   print('migrating project collection...done')
 }
 
-const migrateOrganizationCollection = () => {
-  print('migrating organization collection...')
-
-  const query = {}
-
-  const update = {
-    $unset: {
-      url: ''
-    }
-  }
-
-  db.organization.updateMany(query, update)
-
-  print('migrating organization collection...done')
-}
-
 const harmonizeProjectUrls = () => {
   // Make links to corporate site uniform
   // - only https links
@@ -84,4 +68,3 @@ const harmonizeProjectUrls = () => {
 
 migrateProjectCollection()
 harmonizeProjectUrls()
-migrateOrganizationCollection()

--- a/data-migration/2.x-to-3.x/migrate.js
+++ b/data-migration/2.x-to-3.x/migrate.js
@@ -1,55 +1,91 @@
 /* global db */
 
-const query = {}
+const migrate_project_collection = () => {
 
-// Note: keys 'dataManagementPlanUrl', 'homeUrl', 'imageCaption', and
-// 'softwareSustainabilityPlanUrl' are purposely not set, as they are
-// not required. Users can still set them through the admin
-// interface if they want though.
-const update = {
-  $set: {
-    callUrl: 'https://doi.org/FIXME',
-    codeUrl: 'https://github.com/FIXME',
-    dateEnd: '1901-01-01',
-    dateStart: '1900-01-01',
-    description: 'FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME',
-    grantId: 'FIXME',
-    isPublished: true,
-    'related.organizations': [],
-    'related.projects': [],
-    'related.software': [],
-    tags: [],
-    team: []
-  },
-  $rename: {
-    image: 'imageUrl'
-  },
-  $unset: {
-    corporateUrl: '',
-    principalInvestigator: ''
-  }
+    print("migrating project collection...")
+
+    const query = {}
+
+    // Note: keys 'dataManagementPlanUrl', 'homeUrl', 'imageCaption', and
+    // 'softwareSustainabilityPlanUrl' are purposely not set, as they are
+    // not required. Users can still set them through the admin
+    // interface if they want though.
+    const update = {
+      $set: {
+        callUrl: 'https://doi.org/FIXME',
+        codeUrl: 'https://github.com/FIXME',
+        dateEnd: '1901-01-01',
+        dateStart: '1900-01-01',
+        description: 'FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME',
+        grantId: 'FIXME',
+        isPublished: true,
+        'related.organizations': [],
+        'related.projects': [],
+        'related.software': [],
+        tags: [],
+        team: []
+      },
+      $rename: {
+        image: 'imageUrl'
+      },
+      $unset: {
+        corporateUrl: '',
+        principalInvestigator: ''
+      }
+    }
+
+    db.project.updateMany(query, update)
+
+    print("migrating project collection...done")
+
 }
 
-db.project.updateMany(query, update)
+const migrate_organization_collection = () => {
 
-// Make links to corporate site uniform
-// - only https links
-// - no www subdomain to esciencecenter.nl
+    print("migrating organization collection...")
 
-db.project.find({
-  imageUrl: {
-    $regex: '^http://www.esciencecenter.nl'
-  }
-}).forEach((doc, idoc) => {
-  doc.imageUrl = doc.imageUrl.replace('http://www.esciencecenter.nl', 'https://esciencecenter.nl')
-  db.project.save(doc)
-})
+    const query = {}
 
-db.project.find({
-  imageUrl: {
-    $regex: '^https://www.esciencecenter.nl'
-  }
-}).forEach((doc, idoc) => {
-  doc.imageUrl = doc.imageUrl.replace('https://www.esciencecenter.nl', 'https://esciencecenter.nl')
-  db.project.save(doc)
-})
+    const update = {
+      $unset: {
+        url: ''
+      }
+    }
+
+    db.organization.updateMany(query, update)
+
+    print("migrating organization collection...done")
+}
+
+
+const harmonize_project_urls = () => {
+    // Make links to corporate site uniform
+    // - only https links
+    // - no www subdomain to esciencecenter.nl
+
+    print("harmonizing project urls...")
+
+    db.project.find({
+      imageUrl: {
+        $regex: '^http://www.esciencecenter.nl'
+      }
+    }).forEach((doc, idoc) => {
+      doc.imageUrl = doc.imageUrl.replace('http://www.esciencecenter.nl', 'https://esciencecenter.nl')
+      db.project.save(doc)
+    })
+
+    db.project.find({
+      imageUrl: {
+        $regex: '^https://www.esciencecenter.nl'
+      }
+    }).forEach((doc, idoc) => {
+      doc.imageUrl = doc.imageUrl.replace('https://www.esciencecenter.nl', 'https://esciencecenter.nl')
+      db.project.save(doc)
+    })
+
+    print("harmonizing project urls...done")
+}
+
+migrate_project_collection()
+harmonize_project_urls()
+migrate_organization_collection()


### PR DESCRIPTION
~~This PR removes unused property url from organization schema and updates the migration scripts~~

This PR retains unused property `url` from `organization` schema, but makes it optional. The migration script was also adapted to not include assigning a placeholder url anymore.

Refs: #680

To test, 

1. clear local state including docker bind mounts
1. `docker-compose build && docker-compose up -d && docker-compose logs`
1. check api, e.g. http://localhost/api/organization/commit should have string `url`
1. http://localhost/admin, click new organization

(TBC)

