### PR TITLE
added link to ignore list so we can have meaningful ci again

### DIFF
--- a/.mlc-config.json
+++ b/.mlc-config.json
@@ -18,6 +18,8 @@
         "pattern": "^https://3.92.182.176$"
     }, {
         "pattern": "^https://doi.org/<yourdoi>$"
+    }, {
+        "pattern": "^https://github.com/research-software-directory/research-software-directory/blob/3.0.0/docs/dev.md#verifying-the-local-installation$"
     }],
     "replacementPatterns": [{
         "pattern": "^/",


### PR DESCRIPTION
There's this one link which will only exist once we make the release. It results in the ci always returning red, thus hiding real broken links and other problems. This PR adds this particular link to the ignore list. We can remove it from the list once we have tag `3.0.0` (see #692)

All checks should now be green again.
