### PR TITLE
Render nameSuffix

### DIFF
--- a/frontend/app/application.py
+++ b/frontend/app/application.py
@@ -280,7 +280,10 @@ def human_name_filter(person):
     name = person.get('givenNames') or ''
     if 'nameParticle' in person and person['nameParticle']:
         name += ' ' + person.get('nameParticle', '')
-    return name + ' ' + person.get('familyNames', '')
+    name += ' ' + person.get('familyNames', '')
+    if 'nameSuffix' in person and person['nameSuffix']:
+        name += ' ' + person.get('nameSuffix', '')
+    return name
 
 
 @application.template_filter()

--- a/frontend/tests/test_template_filters.py
+++ b/frontend/tests/test_template_filters.py
@@ -1,0 +1,23 @@
+import pytest
+from app.application import human_name_filter
+
+@pytest.mark.parametrize('person, expected', [
+    ({
+        'givenNames': 'x',
+        'familyNames': 'y',
+    }, 'x y'),
+    ({
+        'nameParticle': 'de',
+        'givenNames': 'x',
+        'familyNames': 'y',
+    }, 'x de y'),
+    ({
+        'givenNames': 'x',
+        'familyNames': 'y',
+        'nameSuffix': 'Jr.',
+    }, 'x y Jr.'),
+])
+def test_human_name_filter(person, expected):
+    result = human_name_filter(person)
+
+    assert result == expected


### PR DESCRIPTION
Fixes #694

## Describe the changes made in this pull request

When `nameSuffix` field is filled for a person it is rendered.

## Instructions to review the pull request

1. Rebuild frontend with `docker-compose build frontend && docker-compose up`
1. In admin inferface set the `nameSuffix` for a person
1. Rebuild cache with `docker-compose exec harvesting python app.py resolve all`
1. Find person in a project/software page
1. Person should be rendered with nameSuffix