### PR TITLE
project index sort by

### DIFF
--- a/frontend/app/application.py
+++ b/frontend/app/application.py
@@ -1,54 +1,63 @@
-from dateutil import parser
-from datetime import datetime
 import json
+import os
+from datetime import datetime
+
+import ago
 import flask
+import htmlmin
 import markdown
 import requests
-import htmlmin
-import ago
-import os
+from dateutil import parser
 from flask import request
 
-application = flask.Flask(__name__, template_folder='../templates', static_folder='../static')
+application = flask.Flask(
+    __name__, template_folder="../templates", static_folder="../static"
+)
 
-api_url = os.environ.get('BACKEND_URL', 'http://localhost:5001')
+api_url = os.environ.get("BACKEND_URL", "http://localhost:5001")
 
 
-@application.route('/sitemap.xml', methods=['GET'])
+@application.route("/sitemap.xml", methods=["GET"])
 def sitemap():
-    url = api_url + '/software?isPublished=true'
+    url = api_url + "/software?isPublished=true"
     all_software = requests.get(url).json()
 
-    response = flask.Response(flask.render_template('sitemap.xml',
-                                                    data=all_software
-                                                    ))
+    response = flask.Response(flask.render_template("sitemap.xml", data=all_software))
     response.headers["Content-Type"] = "application/xml"
     return response
 
 
 def serialize_software_list(swlist):
     def sw_dict(sw):
-        last_update = sw.get('lastCommit', sw.get('updatedAt')) or '2015-01-01T12:00:00Z'
+        last_update = (
+            sw.get("lastCommit", sw.get("updatedAt")) or "2015-01-01T12:00:00Z"
+        )
         return {
-            'numCommits': sw.get('totalCommits'),
-            'numMentions': len(sw.get('related').get('mentions')),
-            'lastUpdate': last_update,
-            'lastUpdateAgo': ago.human(str_to_datetime(last_update), precision=1),
-            'tags': sw.get('tags'),
-            'primaryKey': sw.get('primaryKey'),
-            'brandName': sw.get('brandName'),
-            'shortStatement': sw.get('shortStatement'),
-            'isFeatured': sw.get('isFeatured'),
-            'relatedOrganizations': [
-                { 'foreignKey': { key: org['foreignKey'][key] for key in ['primaryKey', 'name'] } } for org in sw.get('related').get('organizations')],
-            'slug': sw.get('slug'),
+            "numCommits": sw.get("totalCommits"),
+            "numMentions": len(sw.get("related").get("mentions")),
+            "lastUpdate": last_update,
+            "lastUpdateAgo": ago.human(str_to_datetime(last_update), precision=1),
+            "tags": sw.get("tags"),
+            "primaryKey": sw.get("primaryKey"),
+            "brandName": sw.get("brandName"),
+            "shortStatement": sw.get("shortStatement"),
+            "isFeatured": sw.get("isFeatured"),
+            "relatedOrganizations": [
+                {
+                    "foreignKey": {
+                        key: org["foreignKey"][key] for key in ["primaryKey", "name"]
+                    }
+                }
+                for org in sw.get("related").get("organizations")
+            ],
+            "slug": sw.get("slug"),
         }
+
     return json.dumps(list(map(lambda sw: sw_dict(sw), swlist)))
 
 
 def get_software_mentions(software_list):
-    mention_accessor = lambda s: s['related']['mentions']
-    return get_mentions(software_list, mention_accessor)
+    return get_mentions(software_list, lambda s: s["related"]["mentions"])
 
 
 def get_mentions(software_list, mention_accessor):
@@ -58,98 +67,102 @@ def get_mentions(software_list, mention_accessor):
     mentions = dict()
     for software in software_list:
         for mention in mention_accessor(software):
-            mention_id = mention['foreignKey']['primaryKey']['id']
+            mention_id = mention["foreignKey"]["primaryKey"]["id"]
             mentions[mention_id] = {
-                'date': (mention['foreignKey']['date']),
-                'title': (mention['foreignKey']['title']),
-                'url': (mention['foreignKey'].get('url'))  # url could be missing
+                "date": (mention["foreignKey"]["date"]),
+                "title": (mention["foreignKey"]["title"]),
+                "url": (mention["foreignKey"].get("url")),  # url could be missing
             }
 
     past_mentions = remove_future_mentions(mentions)
-    return sorted(past_mentions, key=lambda m: m['date'], reverse=True)
+    return sorted(past_mentions, key=lambda m: m["date"], reverse=True)
 
 
-@application.route('/', methods=['GET'])
-@application.route('/software/', methods=['GET'])
+@application.route("/", methods=["GET"])
+@application.route("/software/", methods=["GET"])
 def index():
-    url = api_url + '/software_cache?isPublished=true'
+    url = api_url + "/software_cache?isPublished=true"
     organizations = [
-        { key: org[key] for key in ['primaryKey', 'name'] } for org in requests.get(api_url + '/organization').json()
+        {key: org[key] for key in ["primaryKey", "name"]}
+        for org in requests.get(api_url + "/organization").json()
     ]
     all_software = requests.get(url).json()
 
-    return flask.render_template('software_index/template.html',
-                                 template_data=all_software,
-                                 data_json=flask.Markup(serialize_software_list(all_software)),
-                                 organizations=flask.Markup(json.dumps(organizations)),
-                                 mentions=get_software_mentions(all_software),
-                                 )
+    return flask.render_template(
+        "software_index/template.html",
+        template_data=all_software,
+        data_json=flask.Markup(serialize_software_list(all_software)),
+        organizations=flask.Markup(json.dumps(organizations)),
+        mentions=get_software_mentions(all_software),
+    )
 
 
 def set_markdown(software, fields):
     for field in fields:
-        if field in software and software[field] and software[field] != '':
+        if field in software and software[field] and software[field] != "":
             software[field] = flask.Markup(markdown.markdown(software[field]))
         else:
             software[field] = None
 
 
-@application.route('/software/<software_id>')
+@application.route("/software/<software_id>")
 def software_product_page_template(software_id):
     url = api_url + "/software_cache/%s" % software_id
     software_dictionary = requests.get(url).json()
     if "error" in software_dictionary:
         return page_not_found("Unknown software id")
-    set_markdown(software_dictionary, ['statement', 'shortStatement', 'readMore'])
+    set_markdown(software_dictionary, ["statement", "shortStatement", "readMore"])
 
-    return flask.render_template('software/template.html',
-                                 software_id=software_id,
-                                 template_data=software_dictionary,
-                                 mention_types=_get_mention_types(),
-                                 )
+    return flask.render_template(
+        "software/template.html",
+        software_id=software_id,
+        template_data=software_dictionary,
+        mention_types=_get_mention_types(),
+    )
 
 
-@application.route('/cite/<software_id>')
+@application.route("/cite/<software_id>")
 def cite(software_id):
     url = api_url + "/software_cache/%s" % software_id
     software_dictionary = requests.get(url).json()
     if "error" in software_dictionary:
         return page_not_found("Unknown software id")
 
-    releases = software_dictionary['releases']
+    releases = software_dictionary["releases"]
 
     for release in releases:
-        if release['tag'] == flask.request.args.get('version'):
-            for file_format in release['files'].keys():
-                if file_format == flask.request.args.get('format'):
+        if release["tag"] == flask.request.args.get("version"):
+            for file_format in release["files"].keys():
+                if file_format == flask.request.args.get("format"):
                     names_and_types = {
                         "bibtex": {
                             "name": "{0}.bib".format(software_id),
-                            "content-type": "application/x-bibtex"
+                            "content-type": "application/x-bibtex",
                         },
-                        "cff": {
-                            "name": "CITATION.cff",
-                            "content-type": "text/yaml"
-                        },
+                        "cff": {"name": "CITATION.cff", "content-type": "text/yaml"},
                         "codemeta": {
                             "name": "codemeta.json",
-                            "content-type": "application/json"
+                            "content-type": "application/json",
                         },
                         "endnote": {
                             "name": "{0}.enw".format(software_id),
-                            "content-type": "text/plain"
+                            "content-type": "text/plain",
                         },
                         "ris": {
                             "name": "{0}.ris".format(software_id),
-                            "content-type": "application/x-research-info-systems"
+                            "content-type": "application/x-research-info-systems",
                         },
                     }
                     return flask.Response(
-                        release['files'][file_format],
+                        release["files"][file_format],
                         headers={
-                            "Content-disposition": "attachment; filename={0}".format(names_and_types[file_format]["name"]),
-                            "Content-Type": names_and_types[file_format]["content-type"]
-                        }
+                            "Content-disposition": "attachment; filename={0}".format(
+                                names_and_types[file_format]["name"]
+                            ),
+                            "Content-Type": names_and_types[file_format][
+                                "content-type"
+                            ],
+                        },
                     )
 
     return flask.abort(404)
@@ -160,87 +173,92 @@ def project_status(start_str, end_str):
     end = str_to_datetime(end_str).replace(tzinfo=None)
     today = datetime.now().replace(tzinfo=None)
     if end < today:
-        return {
-            'status': 'Finished',
-            'progress': 1
-        }
+        return {"status": "Finished", "progress": 1}
     elif start > today:
-        return {
-            'status': 'Starting',
-            'progress': 0
-        }
+        return {"status": "Starting", "progress": 0}
     else:
-        return {
-            'status': 'Running',
-            'progress': (today - start ) / (end - start)
-        }
+        return {"status": "Running", "progress": (today - start) / (end - start)}
 
-@application.route('/projects/<project_id>')
+
+@application.route("/projects/<project_id>")
 def project_page_template(project_id):
     url = api_url + "/project_cache/%s" % project_id
     project_dictionary = requests.get(url).json()
     if "error" in project_dictionary:
         return page_not_found("Unknown project id")
 
-    set_markdown(project_dictionary, ['description'])
+    set_markdown(project_dictionary, ["description"])
 
-    status = project_status(project_dictionary['dateStart'], project_dictionary['dateEnd'])
+    status = project_status(
+        project_dictionary["dateStart"], project_dictionary["dateEnd"]
+    )
 
-    return flask.render_template('project/template.html',
-                                 project_id=project_id,
-                                 template_data=project_dictionary,
-                                 status=status,
-                                 mention_types=_get_mention_types())
+    return flask.render_template(
+        "project/template.html",
+        project_id=project_id,
+        template_data=project_dictionary,
+        status=status,
+        mention_types=_get_mention_types(),
+    )
 
 
 def get_year_from_date_string(date_string):
-    return(date_string[0:4])
+    return date_string[0:4]
 
-@application.route('/projects/')
+
+@application.route("/projects/")
 def project_index_template():
     url = api_url + "/project_cache"
     project_data = requests.get(url).json()
     projects = []
     for project in project_data:
         status = project_status(project["dateStart"], project["dateEnd"])["status"]
-        projects.append({"id": project["primaryKey"]["id"],
-                         "title": project["title"],
-                         "subtitle": project["subtitle"],
-                         "imageUrl": project["imageUrl"],
-                         "yearStart": get_year_from_date_string(project["dateStart"]),
-                         "yearEnd": get_year_from_date_string(project["dateEnd"]),
-                         "status": status,
-                         "lastUpdateAgo": ago.human(str_to_datetime(project["updatedAt"]), precision=1),
-                         })
+        projects.append(
+            {
+                "id": project["primaryKey"]["id"],
+                "title": project["title"],
+                "subtitle": project["subtitle"],
+                "imageUrl": project["imageUrl"],
+                "yearStart": get_year_from_date_string(project["dateStart"]),
+                "yearEnd": get_year_from_date_string(project["dateEnd"]),
+                "status": status,
+                "numMentions": len(project["output"]) + len(project["impact"]),
+                "lastUpdate": project["updatedAt"],
+                "lastUpdateAgo": ago.human(
+                    str_to_datetime(project["updatedAt"]), precision=1
+                ),
+            }
+        )
     mentions = get_project_mentions(project_data)
-    status_choices = ['Starting','Running', 'Finished']
+    status_choices = ["Starting", "Running", "Finished"]
 
-    return flask.render_template('project_index/template.html',
-                                 data_json=flask.Markup(json.dumps(projects)),
-                                 projects=projects,
-                                 status_choices_json=flask.Markup(json.dumps(status_choices)),
-                                 mentions=mentions)
+    return flask.render_template(
+        "project_index/template.html",
+        data_json=flask.Markup(json.dumps(projects)),
+        projects=projects,
+        status_choices_json=flask.Markup(json.dumps(status_choices)),
+        mentions=mentions,
+    )
 
 
 def get_project_mentions(projects):
-    mention_accessor = lambda o:  o['impact'] + o['output']
-    return get_mentions(projects, mention_accessor)
+    return get_mentions(projects, lambda o: o["impact"] + o["output"])
 
 
 def remove_future_mentions(mentions):
-    now = datetime.strftime(datetime.utcnow(), '%Y-%m-%dT%H:%M:%SZ')
-    past_mentions = [mention for mention in mentions.values() if mention['date'] < now]
+    now = datetime.strftime(datetime.utcnow(), "%Y-%m-%dT%H:%M:%SZ")
+    past_mentions = [mention for mention in mentions.values() if mention["date"] < now]
     return past_mentions
 
 
-@application.route('/about')
+@application.route("/about")
 def about_template():
-    return htmlmin.minify(flask.render_template('about/template.html'))
+    return htmlmin.minify(flask.render_template("about/template.html"))
 
 
 @application.errorhandler(404)
 def page_not_found(e):
-    return flask.render_template('404/template.html',e=e,url=request.path)
+    return flask.render_template("404/template.html", e=e, url=request.path)
 
 
 def str_to_datetime(input_string):
@@ -278,101 +296,128 @@ def human_date_month_filter(input_string):
 
 @application.template_filter()
 def human_name_filter(person):
-    name = person.get('givenNames') or ''
-    if 'nameParticle' in person and person['nameParticle']:
-        name += ' ' + person.get('nameParticle', '')
-    name += ' ' + person.get('familyNames', '')
-    if 'nameSuffix' in person and person['nameSuffix']:
-        name += ' ' + person.get('nameSuffix', '')
+    name = person.get("givenNames") or ""
+    if "nameParticle" in person and person["nameParticle"]:
+        name += " " + person.get("nameParticle", "")
+    name += " " + person.get("familyNames", "")
+    if "nameSuffix" in person and person["nameSuffix"]:
+        name += " " + person.get("nameSuffix", "")
     return name
 
 
 @application.template_filter()
 def list_names_filter(contributors):
-    return [c['name'] for c in contributors]
+    return [c["name"] for c in contributors]
 
 
 @application.template_filter()
 def markdown_filter(input_string):
     if not input_string:
-        return ''
+        return ""
     return flask.Markup(markdown.markdown(input_string))
 
 
 @application.template_filter()
 def releases_filter(releases):
-    return [{
-        'doi': release['doi'],
-        'tag': release['tag'],
-        'citability': release['citability']
-    } for release in releases]
+    return [
+        {
+            "doi": release["doi"],
+            "tag": release["tag"],
+            "citability": release["citability"],
+        }
+        for release in releases
+    ]
+
 
 @application.template_filter()
-def no_none_filter(l):
-    return list(filter(lambda x: x is not None, l))
+def no_none_filter(o):
+    return list(filter(lambda x: x is not None, o))
 
-@application.route('/favicon.ico')
+
+@application.route("/favicon.ico")
 def serve_favicon():
-    return application.send_static_file('favicon.ico')
+    return application.send_static_file("favicon.ico")
 
 
-@application.route('/robots.txt')
+@application.route("/robots.txt")
 def serve_robots():
-    return application.send_static_file('robots.txt')
+    return application.send_static_file("robots.txt")
 
-@application.route('/oai-pmh')
+
+@application.route("/oai-pmh")
 def oai_pmh():
 
     supported_verbs = ["ListRecords", "GetRecord"]
-    verb = flask.request.args.get('verb')
-    if not verb in supported_verbs:
-        response = flask.make_response("OAI-PMH verb should be one of [" +
-                   ", ".join(supported_verbs) + "]; other verbs are not " +
-                   "supported at the moment.")
+    verb = flask.request.args.get("verb")
+    if verb not in supported_verbs:
+        response = flask.make_response(
+            "OAI-PMH verb should be one of ["
+            + ", ".join(supported_verbs)
+            + "]; other verbs are not "
+            + "supported at the moment."
+        )
         return response
 
     supported_metadata_prefixes = ["datacite4"]
-    metadata_prefix = flask.request.args.get('metadataPrefix')
-    if not metadata_prefix in supported_metadata_prefixes:
-        response = flask.make_response("'metadataPrefix' should be one of [" +
-                   ", ".join(supported_metadata_prefixes) + "]; other verbs " +
-                   "are not supported at the moment.")
+    metadata_prefix = flask.request.args.get("metadataPrefix")
+    if metadata_prefix not in supported_metadata_prefixes:
+        response = flask.make_response(
+            "'metadataPrefix' should be one of ["
+            + ", ".join(supported_metadata_prefixes)
+            + "]; other verbs "
+            + "are not supported at the moment."
+        )
         return response
 
-    oaipmh_cache_dir = os.path.join('/', 'static', 'oaipmh-cache')
+    oaipmh_cache_dir = os.path.join("/", "static", "oaipmh-cache")
 
-    if verb=='ListRecords':
-        d = os.path.join(oaipmh_cache_dir,'datacite4')
-        f = 'listrecords.xml'
+    if verb == "ListRecords":
+        d = os.path.join(oaipmh_cache_dir, "datacite4")
+        f = "listrecords.xml"
         return flask.send_from_directory(d, f, as_attachment=False)
-    elif verb=='GetRecord':
-        identifier = flask.request.args.get('identifier')
+    elif verb == "GetRecord":
+        identifier = flask.request.args.get("identifier")
         if identifier is None:
             response = flask.make_response("You need to specify an identifier.")
             return response
-        if not identifier[:15]=="oai:zenodo.org:":
-            response = flask.make_response("'oai:zenodo.org:<record_number>' is the only supported identifier format at the moment.")
+        if not identifier[:15] == "oai:zenodo.org:":
+            response = flask.make_response(
+                "'oai:zenodo.org:<record_number>' is the only supported identifier format at the moment."
+            )
             return response
-        d = os.path.join(oaipmh_cache_dir,'datacite4')
-        f = 'record-' + identifier.split(':')[-1] + '.xml'
+        d = os.path.join(oaipmh_cache_dir, "datacite4")
+        f = "record-" + identifier.split(":")[-1] + ".xml"
         return flask.send_from_directory(d, f, as_attachment=False)
+
 
 def _get_mention_types():
     return {
-        'blogPost': {"singular": "Blog post", "plural": "Blog posts"},
-        'book': {"singular": "Book", "plural": "Books"},
-        'bookSection': {"singular": "Book section", "plural": "Book sections"},
-        'computerProgram': {"singular": "Computer program", "plural": "Computer programs"},
-        'conferencePaper': {"singular": "Conference paper", "plural": "Conference papers"},
-        'dataset': {"singular": "Data set", "plural": "Data sets"},
-        'document': {"singular": "Document", "plural": "Documents"},
-        'journalArticle': {"singular": "Journal article", "plural": "Journal articles"},
-        'magazineArticle': {"singular": "Magazine article", "plural": "Magazine articles"},
-        'manuscript': {"singular": "Manuscript", "plural": "Manuscripts"},
-        'newspaperArticle': {"singular": "Newspaper article", "plural": "Newspaper articles"},
-        'presentation': {"singular": "Presentation", "plural": "Presentations"},
-        'report': {"singular": "Report", "plural": "Reports"},
-        'thesis': {"singular": "Thesis", "plural": "Theses"},
-        'videoRecording': {"singular": "Video recording", "plural": "Video recordings"},
-        'webpage': {"singular": "Web page", "plural": "Web pages"},
+        "blogPost": {"singular": "Blog post", "plural": "Blog posts"},
+        "book": {"singular": "Book", "plural": "Books"},
+        "bookSection": {"singular": "Book section", "plural": "Book sections"},
+        "computerProgram": {
+            "singular": "Computer program",
+            "plural": "Computer programs",
+        },
+        "conferencePaper": {
+            "singular": "Conference paper",
+            "plural": "Conference papers",
+        },
+        "dataset": {"singular": "Data set", "plural": "Data sets"},
+        "document": {"singular": "Document", "plural": "Documents"},
+        "journalArticle": {"singular": "Journal article", "plural": "Journal articles"},
+        "magazineArticle": {
+            "singular": "Magazine article",
+            "plural": "Magazine articles",
+        },
+        "manuscript": {"singular": "Manuscript", "plural": "Manuscripts"},
+        "newspaperArticle": {
+            "singular": "Newspaper article",
+            "plural": "Newspaper articles",
+        },
+        "presentation": {"singular": "Presentation", "plural": "Presentations"},
+        "report": {"singular": "Report", "plural": "Reports"},
+        "thesis": {"singular": "Thesis", "plural": "Theses"},
+        "videoRecording": {"singular": "Video recording", "plural": "Video recordings"},
+        "webpage": {"singular": "Web page", "plural": "Web pages"},
     }

--- a/frontend/static/scripts/project_index_scripts.js
+++ b/frontend/static/scripts/project_index_scripts.js
@@ -3,157 +3,203 @@
  * It is served as-is, so please keep everything ES5 compatible.
 */
 
-/*** Copyright 2013 Teun Duynstee Licensed under the Apache License, Version 2.0 ***/
-var firstBy=function(){function n(n){return n}function t(n){return"string"==typeof n?n.toLowerCase():n}function r(r,e){if(e="number"==typeof e?{direction:e}:e||{},"function"!=typeof r){var i=r;r=function(n){return n[i]?n[i]:""}}if(1===r.length){var u=r,o=e.ignoreCase?t:n;r=function(n,t){return o(u(n))<o(u(t))?-1:o(u(n))>o(u(t))?1:0}}return-1===e.direction?function(n,t){return-r(n,t)}:r}function e(n,t){var i="function"==typeof this&&this,u=r(n,t),o=i?function(n,t){return i(n,t)||u(n,t)}:u;return o.thenBy=e,o}return e}();
-/*** https://github.com/component/debounce ***/
-function debounce(n,l,u){function t(){var c=Date.now()-r;c<l&&c>=0?e=setTimeout(t,l-c):(e=null,u||(i=n.apply(o,a),o=a=null))}var e,a,o,r,i;null==l&&(l=100);var c=function(){o=this,a=arguments,r=Date.now();var c=u&&!e;return e||(e=setTimeout(t,l)),c&&(i=n.apply(o,a),o=a=null),i};return c.clear=function(){e&&(clearTimeout(e),e=null)},c.flush=function(){e&&(i=n.apply(o,a),o=a=null,clearTimeout(e),e=null)},c}
+/** Copyright 2013 Teun Duynstee Licensed under the Apache License, Version 2.0 **/
+/** https://github.com/component/debounce **/
+function debounce (n, l, u) {
+  function t () {
+    const c = Date.now() - r
+    c < l && c >= 0 ? e = setTimeout(t, l - c) : (e = null, u || (i = n.apply(o, a), o = a = null))
+  }
+  let e, a, o, r, i
+  null == l && (l = 100)
+  const c = function () {
+    o = this, a = arguments, r = Date.now()
+    const c = u && !e
+    return e || (e = setTimeout(t, l)), c && (i = n.apply(o, a), o = a = null), i
+  }
+  return c.clear = function () {
+    e && (clearTimeout(e), e = null)
+  }, c.flush = function () {
+    e && (i = n.apply(o, a), o = a = null, clearTimeout(e), e = null)
+  },
+  c
+}
 
-function initOverview(projectsData, statusChoicesData) {
-    var device = {
-        phone: 'phone',
-        tablet: 'tablet',
-        desktop: 'desktop'
-    };
+function initOverview (projectsData, statusChoicesData) {
+  const device = {
+    phone: 'phone',
+    tablet: 'tablet',
+    desktop: 'desktop'
+  }
 
-    function getDevice() {
-        return window.innerWidth > 1000 ? device.desktop : (window.innerWidth > 700 ? device.tablet : device.phone);
+  function getDevice () {
+    return window.innerWidth > 1000 ? device.desktop : (window.innerWidth > 700 ? device.tablet : device.phone)
+  }
+
+  function filterStatuses (statuses) {
+    return function (project) {
+      return statuses.length === 0 || statuses.includes(project.status)
     }
+  }
 
-    function filterStatuses(statuses) {
-        return function(project) {
-            return statuses.length === 0 || statuses.includes(project.status);
-        }
+  function filterSearch (searchTerm) {
+    return function (project) {
+      if (!searchTerm) return true
+      const fields = project.title + ' ' + project.subtitle
+      return fields.toLowerCase().indexOf(searchTerm.toLowerCase()) > -1
     }
+  }
 
-    function filterSearch(searchTerm) {
-        return function (project) {
-            if (!searchTerm) return true;
-            var fields = project.title + " " + project.subtitle;
-            return fields.toLowerCase().indexOf(searchTerm.toLowerCase()) > -1;
+  const v = new Vue({
+    el: '#project_index_page',
+    delimiters: ['[[', ']]'],
+    methods: {
+      log: console.log,
+      showPage: function (n) {
+        return n === 1 || n === this.lastPage || Math.abs(n - this.page) <= 2
+      },
+      filtersBeforeEnter: function (el) {
+        el.style.opacity = 0
+        el.style.padding = 0
+        el.style.maxHeight = 0
+      },
+      filtersEnter: function (el, done) {
+        const delay = el.dataset.index * 20
+        setTimeout(function () {
+          el.style.opacity = 1
+          el.style.maxHeight = '5em'
+          el.style.removeProperty('padding')
+        }, delay)
+      },
+      filtersBeforeLeave: function (el) {
+        el.style.opacity = 1
+        el.style.maxHeight = '5em'
+      },
+      filtersLeave: function (el, done) {
+        const delay = el.dataset.index * 20
+        setTimeout(function () {
+          el.style.opacity = 0
+          el.style.maxHeight = 0
+          el.style.padding = 0
+        }, delay)
+      },
+      setSorter: function (sorter) {
+        this.sort = sorter
+        this.sortersOpen = false
+      }
+    },
+    data: {
+      device: getDevice(),
+      page: 1,
+      projects: projectsData,
+      statusChoices: statusChoicesData,
+      mobShowFilters: false,
+      filter: {
+        search: '',
+        statuses: []
+      },
+      statusesFilterOpen: getDevice() !== device.phone,
+      sorters: ['Last updated', 'Most mentions'],
+      sortersOpen: false,
+      sort: 'Last updated'
+
+    },
+    computed: {
+      statusesWithCount: function () {
+        const initialValue = {}
+        this.statusChoices.forEach(name => {
+          initialValue[name] = 0
+        })
+        const counts = this.filteredProjects.map(d => d.status).reduce(
+          (allStatuses, status) => {
+            allStatuses[status]++
+            return allStatuses
+          },
+          initialValue
+        )
+        return this.statusChoices.map(name => {
+          return {
+            name,
+            count: counts[name]
+          }
+        })
+      },
+      filteredProjects: function () {
+        return this.projects
+          .filter(filterStatuses(this.filter.statuses))
+          .filter(filterSearch(this.filter.search))
+      },
+      sortedProjects: function () {
+        function updatedSorter (a, b) {
+          return b.lastUpdate > a.lastUpdate ? 1 : (a.lastUpdate > b.lastUpdate ? -1 : 0)
         }
+        function keyCountSorter (key) {
+          return function (a, b) {
+            return b[key] - a[key]
+          }
+        }
+        function sortFunction (sortVal) {
+          switch (sortVal) {
+            case 'Last updated':
+              return updatedSorter
+            case 'Most mentions':
+              return keyCountSorter('numMentions')
+            default:
+              return updatedSorter
+          }
+        }
+
+        return this.filteredProjects.sort(sortFunction(this.sort))
+      },
+      pagedProjects: function () {
+        const offset = this.pageSize * (this.page - 1)
+        return this.sortedProjects.slice(offset, offset + this.pageSize)
+      },
+
+      lastPage: function () {
+        return Math.ceil(this.filteredProjects.length / this.pageSize)
+      },
+
+      pageSize: function () {
+        return {
+          phone: 5,
+          tablet: 10,
+          desktop: 10
+        }[this.device]
+      }
+    },
+    watch: {
+      page: {
+        handler: function () { window.scrollTo(0, 0) }
+      },
+      sort: {
+        handler: function () { this.page = 1 }
+      },
+      pageSize: {
+        handler: function () { this.page = 1 }
+      },
+      filter: {
+        handler: function () { this.page = 1 },
+        deep: true
+      },
+      'filter.search': {
+        handler: function () { gaSearch(this.filter.search) }
+      }
     }
-
-    var v = new Vue({
-        el: '#project_index_page',
-        delimiters: ["[[", "]]"],
-        methods: {
-            log: console.log,
-            showPage: function (n) {
-                return n === 1 || n === this.lastPage || Math.abs(n - this.page) <= 2
-            },
-            filtersBeforeEnter: function (el) {
-                el.style.opacity = 0;
-                el.style.padding = 0;
-                el.style.maxHeight = 0;
-            },
-            filtersEnter: function(el, done) {
-                var delay = el.dataset.index * 20;
-                setTimeout(function () {
-                    el.style.opacity = 1;
-                    el.style.maxHeight = '5em';
-                    el.style.removeProperty('padding');
-                }, delay );
-            },
-            filtersBeforeLeave: function (el) {
-                el.style.opacity = 1;
-                el.style.maxHeight = '5em';
-            },
-            filtersLeave: function(el, done) {
-                var delay = el.dataset.index * 20;
-                setTimeout(function () {
-                    el.style.opacity = 0;
-                    el.style.maxHeight = 0;
-                    el.style.padding = 0;
-                }, delay );
-            }
-        },
-        data: {
-            device: getDevice(),
-            page: 1,
-            projects: projectsData,
-            statusChoices: statusChoicesData,
-            mobShowFilters: false,
-            filter: {
-                search: '',
-                statuses: []
-            },
-            statusesFilterOpen: getDevice() !== device.phone,
-        },
-        computed: {
-            statusesWithCount: function() {
-                var initialValue = {};
-                this.statusChoices.forEach(name => {
-                    initialValue[name] = 0;
-                });
-                var counts = this.filteredProjects.map(d => d.status).reduce(
-                    (allStatuses, status) => {
-                        allStatuses[status]++;
-                        return allStatuses;
-                    },
-                    initialValue
-                );
-                return this.statusChoices.map(name => {
-                    return {
-                        name,
-                        count: counts[name]
-                    }
-                });
-            },
-            filteredProjects: function () {
-                return this.projects
-                    .filter(filterStatuses(this.filter.statuses))
-                    .filter(filterSearch(this.filter.search));
-            },
-            sortedProjects: function () {
-                // TODO implement sort
-                return this.filteredProjects;
-            },
-            pagedProjects: function () {
-                var offset = this.pageSize * (this.page - 1);
-                return this.sortedProjects.slice(offset, offset + this.pageSize);
-            },
-
-            lastPage: function () {
-                return Math.ceil(this.filteredProjects.length / this.pageSize);
-            },
-
-            pageSize: function() {
-                return {
-                    phone: 5,
-                    tablet: 10,
-                    desktop: 10
-                }[this.device];
-            }
-        },
-        watch: {
-            page: {
-                handler: function () { window.scrollTo(0,0); }
-            },
-            pageSize: {
-                handler: function () { this.page = 1; }
-            },
-            filter: {
-                handler: function () { this.page = 1; },
-                deep: true
-            },
-            'filter.search': {
-                handler: function() { gaSearch(this.filter.search); }
-            }
-        }
-    });
-    window.v = v;
-    window.addEventListener('resize', debounce(function(event) {
-        v.device = getDevice();
-    }, 200));
+  })
+  window.v = v
+  window.addEventListener('resize', debounce(function (event) {
+    v.device = getDevice()
+  }, 200))
 }
 
 // Beamer Mode | Press 'Ctrl + b' to darken the grey backgrounds
 // ---------------------------------------------------------------------
-function KeyPress(e) {
-    var bodyel = document.querySelector('body');
-    var evtobj = window.event? event : e
-    if (evtobj.keyCode == 66 && evtobj.ctrlKey){
-        bodyel.classList.toggle('beamer-mode');
-    }
+function KeyPress (e) {
+  const bodyel = document.querySelector('body')
+  const evtobj = window.event ? event : e
+  if (evtobj.keyCode === 66 && evtobj.ctrlKey) {
+    bodyel.classList.toggle('beamer-mode')
+  }
 }
-document.onkeydown = KeyPress;
+document.onkeydown = KeyPress

--- a/frontend/style/templates/_project.scss
+++ b/frontend/style/templates/_project.scss
@@ -631,7 +631,7 @@
 // Related tools
 // -----------------------------------
 
-#related-tools{
+  #related-tools{
     .container{
         padding-top: 70px;
         padding-bottom: 30px;
@@ -640,76 +640,82 @@
         margin: 60px 0px 20px 0px;
         border-top: 2px solid $divider;
     }
-}
+  }
 
 
-#search-project {
+  #sort-project {
+    margin-top: 30px;
+    margin-bottom: 0;
+  }
 
-  line-height: 6rem;
-  margin: 2.5em 0 auto; 
-  max-width: $contentWidth;
-  padding: 0 40px;
+
+  #search-project {
+
+    line-height: 6rem;
+    margin: 2.5em 0 auto; 
+    max-width: $contentWidth;
+    padding: 0 40px;
   
-  .search-bar {
-    height: 6rem;
-    font-size: 1.8rem;
-    display: flex;
-    position:relative;
-
-    &_button{
-      position:absolute;
-      
-      right:0;
-      cursor: pointer;
-      background-color: $dark;
+    .search-bar {
       height: 6rem;
-      width: 6rem;
-      display:flex;
-      justify-content: center;
-      align-items: center;
+      font-size: 1.8rem;
+      display: flex;
+      position:relative;
 
-      .icon{
-        width: 2.4rem;
-        height: 2.4rem;
-        transform: scale(0.9);
-        fill: white;
-        transition: transform 0.17s ease;
-      }
-    }
-
-    @include bp(max, $tablet){
-      font-size: 1.2rem;
-    }
-
-    input[type="text"] {
-      font-size: inherit;
-      padding: 0 1em;
-      height: 100%;
-      z-index: +1;
-      flex:1;
-      background-color: transparent;
-      border: none;
-      vertical-align: middle;
-      transition: background-color .3s ease;
-
-      &:focus{
-        outline:0;
-        background-color: darken( $light, 6% );
-        margin-right: 6rem;
-      }
-    }
-
-    &:hover{
-      .search-bar_button{
-        background-color: $primaryColor;
+      &_button{
+        position:absolute;
+      
+        right:0;
+        cursor: pointer;
+        background-color: $dark;
+        height: 6rem;
+        width: 6rem;
+        display:flex;
+        justify-content: center;
+        align-items: center;
 
         .icon{
-          transform: scale(1);
+          width: 2.4rem;
+          height: 2.4rem;
+          transform: scale(0.9);
+          fill: white;
+          transition: transform 0.17s ease;
         }
       }
-    }
 
+      @include bp(max, $tablet){
+        font-size: 1.2rem;
+      }
+
+      input[type="text"] {
+        font-size: inherit;
+        padding: 0 1em;
+        height: 100%;
+        z-index: +1;
+        flex:1;
+        background-color: transparent;
+        border: none;
+        vertical-align: middle;
+        transition: background-color .3s ease;
+
+        &:focus{
+          outline:0;
+          background-color: darken( $light, 6% );
+          margin-right: 6rem;
+        }
+      }
+
+      &:hover{
+        .search-bar_button{
+          background-color: $primaryColor;
+
+          .icon{
+            transform: scale(1);
+          }
+        }
+      }
+
+    }
   }
-}
 
 }

--- a/frontend/templates/project_index/template.html
+++ b/frontend/templates/project_index/template.html
@@ -25,20 +25,41 @@
               Directory</a> — the content management system for research software.</p>
         </div>
       </div>
-    </div>
-  </section>
 
-  <section>
-    <div id="search-project" class="row" v-cloak>
-      <div class="col-1-4">
+      <div id="search-project" class="row" v-cloak>
+        <div class="col-1-4">
+        </div>
+        <div class="col-3-4 search-bar bg-light">
+          <input type='text' v-model="filter.search" id="input" placeholder="Start typing here to search for project">
+          <div class="search-bar_button">
+            <svg class="icon">
+              <use xlink:href="{{url_for('static', filename='icons/icons.svg')}}#icon-search"></use>
+            </svg>
+          </div>
+        </div>
       </div>
 
-      <div class="col-3-4 search-bar bg-light">
-        <input type='text' v-model="filter.search" id="input" placeholder="Start typing here to search for project">
-        <div class="search-bar_button">
-          <svg class="icon">
-            <use xlink:href="{{url_for('static', filename='icons/icons.svg')}}#icon-search"></use>
-          </svg>
+      <div id="sort-project" class="row" v-cloak>
+        <div class="col-3-4">
+        </div>
+
+        <div id="sorter" class="col-1-4" v-cloak>
+          <div class="text">Sort by:</div>
+          <div :class="['dropdown', {'is-active': sortersOpen}]">
+            <div class="dropdown_button dropdown_button--dark" @click="sortersOpen = !sortersOpen">
+              <span>[[sort]]</span>
+              <svg class="icon"><use xlink:href="{{url_for('static', filename='icons/icons.svg')}}#icon-chev-down"></use></svg>
+            </div>
+            <div class="dropdown_panel dropdown_panel--dark is-active">
+              <ul>
+                <li v-for="sorter in sorters" :class="{'is-active': sort==sorter}">
+                  <a class="inside" href="#" @click.stop.prevent="setSorter(sorter)">
+                    <span>[[sorter]]</span>
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
# Pull request details

Adds sort by funcion to project index page

## List of related issues or pull requests

Refs: #653 

## Describe the changes made in this pull request

Copied sort by drop down menu from software index to project index (`frontend/templates/project_index/template.html`). Implemented sorting code (`frontend/static/scripts/project_index_scripts.js`). Added required project json fields to frontend (`frontend/app/application.py`). Fixed new drop down menu position in css (`frontend/style/templates/_project.scss`). Fixed dozens of linking errors (still dozens to go...).

## Instructions to review the pull request

After loading this PR a drop down menu should appear top right of the project index page (long arrow in image). There are two sorting options: last updated project first (default). The last update time is mentioned on the project index page (bottom left for each project, short arrows in image). The second sorting option is most mentions (inputs+impact) first. The inputs and impacts are listed on the separate project pages. 

Verify that changing the value of the drop down menu changes the order of the projects and check if the order of the projects corresponds to that of the chosen sort option.

![Screenshot from 2020-11-30 18-32-22](https://user-images.githubusercontent.com/3670455/100644056-1f879b80-333b-11eb-94e5-6c950996de06.png)
