### PR TITLE
change organization img width to work on ipad

### DIFF
--- a/frontend/style/templates/_project.scss
+++ b/frontend/style/templates/_project.scss
@@ -146,7 +146,7 @@
 
   .organisation {
     img {
-      width: 80%;
+      width: 300px;
       margin-left: auto;
       margin-right: auto;
       padding-top: 10px;


### PR DESCRIPTION
# Pull request details
new css rules for organization image/logo 

## List of related issues or pull requests

Refs: #596 


## Describe the changes made in this pull request
large window
![image](https://user-images.githubusercontent.com/6087314/100746033-73988b80-33e0-11eb-83c9-0606aff41486.png)
small window (like ipad)
![image](https://user-images.githubusercontent.com/6087314/100746108-9165f080-33e0-11eb-9683-8833f3c15611.png)



## Instructions to review the pull request
Go to any project with organizations (for instance ABC-muse) and play with the window width. 