### PR TITLE
align search-bar on project index (#716)

### DIFF
--- a/frontend/templates/project_index/template.html
+++ b/frontend/templates/project_index/template.html
@@ -29,16 +29,18 @@
   </section>
 
   <section>
-    <div id="search-project" class="row" v-cloak>
-      <div class="col-1-4">
-      </div>
+    <div class="container">
+      <div id="search-project" class="row" v-cloak>
+        <div class="col-1-4">
+        </div>
 
-      <div class="col-3-4 search-bar bg-light">
-        <input type='text' v-model="filter.search" id="input" placeholder="Start typing here to search for project">
-        <div class="search-bar_button">
-          <svg class="icon">
-            <use xlink:href="{{url_for('static', filename='icons/icons.svg')}}#icon-search"></use>
-          </svg>
+        <div class="col-3-4 search-bar bg-light">
+          <input type='text' v-model="filter.search" id="input" placeholder="Start typing here to search for project">
+          <div class="search-bar_button">
+            <svg class="icon">
+              <use xlink:href="{{url_for('static', filename='icons/icons.svg')}}#icon-search"></use>
+            </svg>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
# Pull request details

Wrapped searchbar div in an extra container div to mimic the structure of the project cards

## List of related issues or pull requests

Refs: #716


## Describe the changes made in this pull request

Search bar is always in the same position sort of centered above the cards on the project page, no matter the width of the window.
![image](https://user-images.githubusercontent.com/6087314/100748529-b871f180-33e3-11eb-988f-e0fe0c582021.png)



## Instructions to review the pull request
Go to the project index page and see that it doesn't look off anymore in for any page width.