### PR TITLE
add style for cleaner project tiles (#661)

### DIFF
--- a/frontend/style/templates/_project.scss
+++ b/frontend/style/templates/_project.scss
@@ -562,9 +562,7 @@
     justify-content: space-between;
 
     .project-item {
-      &:not(:last-child) {
-        margin-bottom: 2em;
-      }
+      margin-bottom: 0;
 
       width: 50%;
 
@@ -602,6 +600,9 @@
         font-size: 2rem;
         line-height: 1.3em;
         margin-bottom: 0.2em;
+      }
+      .card-text {
+        min-height: 8em;
       }
       .author {
         margin-top: 0.3em;

--- a/frontend/templates/project_index/template.html
+++ b/frontend/templates/project_index/template.html
@@ -129,7 +129,7 @@
                     <img :src="'data:' + (project.image.mimeType) + ';base64,' + (project.image.data)" alt="" >
                   </div>
                   <div>
-                    <div>
+                    <div class="card-text">
                       <h2 class="title">[[project.title]]</h2>
                       <p class="description">[[project.subtitle]]</p>
                     </div>


### PR DESCRIPTION
# Pull request details
Cards look more like the mockup. They still have the zooming effect on hover event for the image. That doesn't look nice as the images pops out of the card. 
## List of related issues or pull requests

Refs: #661 


## Describe the changes made in this pull request

<!-- include screenshots if that helps the review -->
![image](https://user-images.githubusercontent.com/6087314/100756905-03910200-33ee-11eb-93f9-d5bccd2c41ee.png)



## Instructions to review the pull request
